### PR TITLE
Fix right sidebar hover when right ribbon is missing

### DIFF
--- a/coordinate-based-sidebar-hover-67fd03.md
+++ b/coordinate-based-sidebar-hover-67fd03.md
@@ -31,16 +31,20 @@ One `document.mousemove` listener, gated by `requestAnimationFrame` for perf:
    - **Leaving right region** -> collapse right sidebar (after delay if configured)
 4. No-op if region unchanged
 
-### Modal/menu handling
+### Overlay handling (generic)
 
-Instead of checking `isModalOrMenuOpen()` on every mousemove, **freeze the current region** when a modal/menu opens. This prevents any expand/collapse while the modal is active, without per-frame DOM queries:
+Obsidian renders all overlays (modals, menus, suggestion popups, tooltips, color pickers, context menus, etc.) **outside** `workspace.containerEl` -- they are appended to `document.body`, not inside `.app-container > .workspace`. This means a single containment check on the event target replaces all class-specific detection:
 
-- Use a `MutationObserver` on `document.body` watching for `.modal-container` / `.menu` additions/removals
-- When modal opens: set `frozen = true`, record current sidebar states
-- When modal closes: set `frozen = false`, re-evaluate region from last known mouse position
-- The mousemove handler early-returns when `frozen`
+```ts
+if (!this.app.workspace.containerEl.contains(event.target as Node)) return;
+```
 
-Alternative (simpler): just skip collapse/expand actions when `isModalOrMenuOpen()` returns true. The check is a single `querySelector` call, which is cheap. The MutationObserver approach avoids even that, but adds complexity. **I'd go with the simpler approach unless perf is a concern.**
+If the mouse is over any overlay, `event.target` will be inside that overlay, not inside the workspace. The check is:
+- **Generic**: handles every overlay type, current and future, with no class names to maintain
+- **Free**: `event.target` is already on the event object; `contains()` is a single DOM tree walk, no querySelector
+- **No MutationObserver needed**, no frozen state, no `isModalOrMenuOpen()` method
+
+This also means `isModalOrMenuOpen()` (which hardcodes `.modal-container` and `.menu`) is removed entirely.
 
 ### What gets removed
 
@@ -85,7 +89,7 @@ document mousemove (rAF-throttled):
   - if mouse NOT in left region AND left sidebar is expanded AND not pinned -> collapse left
   - if mouse NOT in right region AND right sidebar is expanded AND not pinned -> collapse right
   - if mouse near right edge (< RIGHT_EDGE_TRIGGER_PX from wsWidth) -> expand right
-  - skip all if isModalOrMenuOpen()
+  - skip all if event.target is outside workspace.containerEl (generic overlay guard)
 document mouseleave -> collapse both (unchanged)
 ribbon dblclick -> toggle pin (unchanged)
 ```
@@ -94,6 +98,7 @@ ribbon dblclick -> toggle pin (unchanged)
 - rootSplit mouseenter handler
 - All mouseenter/mouseleave on leftSidebar, rightSidebar, leftRibbon, rightRibbon (hover tracking)
 - `isHoveringLeftRegion`, `isHoveringRightRegion`, `isRightEdgeHovering` flags
+- `isModalOrMenuOpen()` method
 
 ### quick-peek-sidebar
 
@@ -104,6 +109,7 @@ document mousemove (rAF-throttled):
   - compute regions (same math, using leftSplit.size, rightSplit.size)
   - if mouse NOT in left region AND left not pinned AND not isActivelyEditing() -> schedule collapseLeft (with sidebarDelay)
   - if mouse NOT in right region AND right not pinned AND not isActivelyEditing() -> schedule collapseRight (with sidebarDelay)
+  - skip all if event.target is outside workspace.containerEl (generic overlay guard)
   - skip all if onlyWhenFocused && !document.hasFocus()
 document mouseleave -> collapse both (unchanged)
 document click -> collapse on editor click (unchanged)

--- a/coordinate-based-sidebar-hover-67fd03.md
+++ b/coordinate-based-sidebar-hover-67fd03.md
@@ -1,6 +1,6 @@
 # Coordinate-based sidebar hover architecture
 
-Replace all mouseenter/mouseleave/elementFromPoint sidebar detection with a single `document.mousemove` handler that uses coordinate math against stored sidebar sizes to determine which region the mouse is in.
+Replace all mouseenter/mouseleave/elementFromPoint sidebar detection with a single `document.mousemove` handler that uses coordinate math to drive both expand and collapse. Pin is toggled via the sidebar toggle buttons.
 
 ## Key discovery
 
@@ -14,7 +14,7 @@ Obsidian stores `leftSplit.size` and `rightSplit.size` (e.g. 325) even when side
            ribbonRight              ribbonRight+leftSize   wsWidth-rightSize            wsWidth
 ```
 
-The right ribbon is collapsed (width 0) in Obsidian, so it doesn't affect layout.
+The right ribbon is empty (0px wide) in standard Obsidian and plays no role.
 
 ## Architecture (shared by both plugins)
 
@@ -22,58 +22,113 @@ The right ribbon is collapsed (width 0) in Obsidian, so it doesn't affect layout
 
 One `document.mousemove` listener, gated by `requestAnimationFrame` for perf:
 
-1. Compute `ribbonRight`, `leftSize`, `rightSize`, `wsWidth` on each frame
-2. Determine region: `left` | `editor` | `right` based on `event.clientX`
-3. On region transition (tracked via `currentRegion` field):
-   - **Entering left region** -> expand left sidebar
-   - **Entering right region** -> expand right sidebar  
-   - **Leaving left region** -> collapse left sidebar (after delay if configured)
-   - **Leaving right region** -> collapse right sidebar (after delay if configured)
-4. No-op if region unchanged
+```
+document mousemove (rAF-throttled):
+  guard: skip if event.target outside workspace.containerEl  (generic overlay guard)
 
-### Overlay handling (generic)
+  compute:
+    ribbonRight    = leftRibbon.containerEl.getBoundingClientRect().right
+    leftSize       = leftSplit.size
+    rightSize      = rightSplit.size
+    wsWidth        = workspace.containerEl.clientWidth
+    x              = event.clientX
 
-Obsidian renders all overlays (modals, menus, suggestion popups, tooltips, color pickers, context menus, etc.) **outside** `workspace.containerEl` -- they are appended to `document.body`, not inside `.app-container > .workspace`. This means a single containment check on the event target replaces all class-specific detection:
+  LEFT:
+    inRibbon     = x < ribbonRight
+    inLeftRegion = x < ribbonRight + leftSize
+    if inRibbon AND left collapsed AND not pinned -> expand left
+    if !inLeftRegion AND left expanded AND not pinned -> schedule collapse left
+
+  RIGHT:
+    inRightTrigger = x > wsWidth - RIGHT_EDGE_TRIGGER_PX
+    inRightRegion  = x > wsWidth - rightSize
+    if inRightTrigger AND right collapsed AND not pinned -> expand right
+    if !inRightRegion AND right expanded AND not pinned -> schedule collapse right
+```
+
+**Left expand trigger is ribbon-only** (`x < ribbonRight`, ~44px) -- matches original behavior. Once expanded, the full left region keeps it open. Collapse fires when mouse leaves the full left region.
+
+**Right expand trigger is edge proximity** (`x > wsWidth - 20px`) -- right ribbon doesn't exist. Once expanded, the full right region keeps it open.
+
+### Overlay guard (generic)
+
+Obsidian appends all overlays (modals, menus, suggestion popups, tooltips, context menus, etc.) to `document.body` outside `workspace.containerEl`. When the mouse is over any overlay, `event.target` is not inside the workspace:
 
 ```ts
 if (!this.app.workspace.containerEl.contains(event.target as Node)) return;
 ```
 
-If the mouse is over any overlay, `event.target` will be inside that overlay, not inside the workspace. The check is:
-- **Generic**: handles every overlay type, current and future, with no class names to maintain
-- **Free**: `event.target` is already on the event object; `contains()` is a single DOM tree walk, no querySelector
-- **No MutationObserver needed**, no frozen state, no `isModalOrMenuOpen()` method
+- **Generic**: handles every overlay type, current and future, no class names
+- **Free**: `event.target` is already on the event; `contains()` is a single DOM tree walk
+- Replaces `isModalOrMenuOpen()` entirely
 
-This also means `isModalOrMenuOpen()` (which hardcodes `.modal-container` and `.menu`) is removed entirely.
+### Pin via sidebar toggle buttons
+
+The sidebar toggle buttons (`.sidebar-toggle-button.mod-left` / `.mod-right`) are the natural pin trigger -- visible on both sides, discoverable, already associated with sidebar state in the user's mental model.
+
+Intercept click on these buttons: `preventDefault` + `stopPropagation` to suppress Obsidian's default toggle, then toggle `leftPin` / `rightPin` instead. Since the plugin controls expand/collapse, the default toggle is redundant.
+
+```ts
+const leftToggle = document.querySelector('.sidebar-toggle-button.mod-left');
+this.registerDomEvent(leftToggle, 'click', (e) => {
+  e.preventDefault();
+  e.stopPropagation();
+  if (this.settings.leftSideEnabled) {
+    this.settings.leftPin = !this.settings.leftPin;
+    this.saveSettings();
+  }
+});
+```
+
+Same pattern for `.mod-right`. Replaces dblclick-on-ribbon for left, and provides a working pin trigger for right (which had no working trigger before).
+
+### Collapse delay handling
+
+1. When mouse leaves a region, start a collapse timer
+2. If mouse re-enters the region before the timer fires, cancel it
+3. Timer callback re-checks region before collapsing
+
+```ts
+private collapseLeftTimer: number | null = null;
+
+// On leaving left region:
+if (!inLeftRegion && !leftSplit.collapsed && !pinned) {
+  if (!this.collapseLeftTimer) {
+    this.collapseLeftTimer = window.setTimeout(() => {
+      this.collapseLeftTimer = null;
+      if (this.currentRegion !== 'left') {
+        this.collapseSidebar(this.leftSidebar);
+      }
+    }, this.settings.sidebarDelay ?? 0);
+  }
+}
+// On entering left region:
+if (inLeftRegion && this.collapseLeftTimer) {
+  clearTimeout(this.collapseLeftTimer);
+  this.collapseLeftTimer = null;
+}
+```
+
+For expand-on-hover, collapse delay is 0 (instant). For quick-peek-sidebar, it's `settings.sidebarDelay` (default 150ms).
 
 ### What gets removed
 
 - All `mouseenter`/`mouseleave` handlers on sidebar containers, ribbons, and rootSplit
-- All hover tracking flags (`isHoveringLeftRegion`, `isHoveringRightRegion`, `isHoveringLeft`, `isHoveringRight`)
+- All hover tracking flags (`isHoveringLeftRegion`, `isHoveringRightRegion`, `isHoveringLeft`, `isHoveringRight`, `isRightEdgeHovering`)
 - All `elementFromPoint` calls
 - All CSS selector matching on `relatedTarget` / `event.target`
+- `isModalOrMenuOpen()` method (hardcoded `.modal-container` / `.menu`)
+- Right ribbon references (it has no width and no icons)
 - The right trigger zone DOM element (quick-peek-sidebar) -- coordinate check replaces it
-- The `isRightEdgeHovering` flag (expand-on-hover) -- region transition replaces it
+- Ribbon dblclick pin handler -- toggle button click replaces it
 
 ### What stays
 
-- **Ribbon mouseenter** for left sidebar expansion trigger (expand-on-hover only -- it doesn't use the coordinate approach for initial trigger, only for deciding when to collapse)
-- **Pin/dblclick** handlers
-- **document mouseleave** (window exit -> collapse both)
-- **Resize handle mouseenter** for saving width on drag
+- **Resize handle mouseenter** -- saves sidebar width to settings on drag start
+- **document mouseleave** -- collapse both when cursor exits window
 - **document click** handler (quick-peek-sidebar)
 - **layout-change** handler (quick-peek-sidebar)
 - All settings, hotkey commands, CSS variables, overlay mode
-
-Wait -- actually, if we're doing full coordinate-based monitoring, the ribbon mouseenter is redundant. The mousemove handler already detects "mouse entered left region" and expands. The ribbon mouseenter handler is only needed if we want expansion *only* from the ribbon (not from the full sidebar region). 
-
-**Decision point**: Should expansion trigger when the mouse enters *any* part of the left region (x < ribbonRight + leftSize), or only when it enters the ribbon strip (x < ribbonRight)?
-
-For **expand-on-hover**: the original behavior is ribbon-only trigger. But the user wants the sidebar to stay open when hovering its content area. So: **expand when entering the ribbon OR when the sidebar is already expanded and mouse stays in its region. Collapse only when mouse leaves the region.**
-
-This simplifies to: track whether the sidebar is expanded via `leftSplit.collapsed`. If the mouse is in the left region AND sidebar is collapsed, only expand from the ribbon trigger. If the mouse is in the left region AND sidebar is expanded, keep it open. If the mouse leaves the left region AND sidebar is expanded, collapse it.
-
-For **quick-peek-sidebar**: similar, but it has configurable pixel triggers (e.g. 20px from left edge) and expand delays.
 
 ## Plugin-specific changes
 
@@ -82,23 +137,22 @@ For **quick-peek-sidebar**: similar, but it has configurable pixel triggers (e.g
 **setEvents rewrite:**
 
 ```
-ribbon mouseenter -> expandSidebar (existing trigger, unchanged)
-resize handle mouseenter -> expandSidebar + save size (unchanged)
 document mousemove (rAF-throttled):
-  - compute regions from leftSplit.size, rightSplit.size, ribbon rect, wsWidth
-  - if mouse NOT in left region AND left sidebar is expanded AND not pinned -> collapse left
-  - if mouse NOT in right region AND right sidebar is expanded AND not pinned -> collapse right
-  - if mouse near right edge (< RIGHT_EDGE_TRIGGER_PX from wsWidth) -> expand right
-  - skip all if event.target is outside workspace.containerEl (generic overlay guard)
-document mouseleave -> collapse both (unchanged)
-ribbon dblclick -> toggle pin (unchanged)
+  [unified expand + collapse logic above]
+resize handle mouseenter -> save size to settings (expand is handled by mousemove)
+document mouseleave -> collapse both
+.sidebar-toggle-button.mod-left click -> toggle leftPin
+.sidebar-toggle-button.mod-right click -> toggle rightPin
 ```
 
 **Remove entirely:**
-- rootSplit mouseenter handler
-- All mouseenter/mouseleave on leftSidebar, rightSidebar, leftRibbon, rightRibbon (hover tracking)
+- Ribbon mouseenter expand handlers (left and right)
+- Ribbon dblclick pin handlers
+- rootSplit mouseenter collapse handler
+- All sidebar/ribbon mouseenter/mouseleave hover tracking
 - `isHoveringLeftRegion`, `isHoveringRightRegion`, `isRightEdgeHovering` flags
 - `isModalOrMenuOpen()` method
+- All right ribbon references
 
 ### quick-peek-sidebar
 
@@ -106,67 +160,31 @@ ribbon dblclick -> toggle pin (unchanged)
 
 ```
 document mousemove (rAF-throttled):
-  - compute regions (same math, using leftSplit.size, rightSplit.size)
-  - if mouse NOT in left region AND left not pinned AND not isActivelyEditing() -> schedule collapseLeft (with sidebarDelay)
-  - if mouse NOT in right region AND right not pinned AND not isActivelyEditing() -> schedule collapseRight (with sidebarDelay)
-  - skip all if event.target is outside workspace.containerEl (generic overlay guard)
-  - skip all if onlyWhenFocused && !document.hasFocus()
-document mouseleave -> collapse both (unchanged)
-document click -> collapse on editor click (unchanged)
+  [unified expand + collapse logic above]
+  skip if onlyWhenFocused && !document.hasFocus()
+document mouseleave -> collapse both
+document click -> collapse on editor click
+.sidebar-toggle-button.mod-left click -> toggle leftPin
+.sidebar-toggle-button.mod-right click -> toggle rightPin
 ```
 
 **attachManualEvents rewrite:**
 
 Keep:
-- leftRibbonMouseEnterHandler (ribbon trigger for left sidebar)
-- leftSplit.containerEl mouseenter -> set isHoveringLeft, add 'hovered' class, trigger expand if collapsed (this is still needed for CSS animation class)
-- rightSplit.containerEl mouseenter -> same for right
-- resize handle mouseenter triggers
-
-Change:
-- Remove `leftSplitMouseLeaveHandler` and `rightSplitMouseLeaveHandler` entirely -- collapse is now handled by the coordinate-based mousemove
-- Remove the right trigger zone DOM element -- coordinate check replaces it
+- Resize handle mouseenter triggers (save size)
 
 Remove:
+- leftRibbonMouseEnterHandler (mousemove handles expand)
+- leftSplit/rightSplit containerEl mouseenter/mouseleave handlers
+- leftSplitMouseLeaveHandler / rightSplitMouseLeaveHandler
 - rootSplit mouseenter handler
+- Right trigger zone DOM element
 
-**The `hovered` CSS class**: quick-peek-sidebar uses this class for CSS transitions. We can add it when expanding and remove it when collapsing, instead of on mouseenter/mouseleave. This decouples it from DOM events.
-
-## Collapse delay handling
-
-Both plugins support configurable collapse delays. With the coordinate approach:
-
-1. When mouse leaves a region, start a collapse timer
-2. If mouse re-enters the region before the timer fires, cancel it
-3. The timer callback checks the region again before collapsing
-
-```ts
-private collapseLeftTimer: number | null = null;
-
-// In mousemove, on leaving left region:
-if (!inLeftRegion && !leftSplit.collapsed && !pinned) {
-  if (!this.collapseLeftTimer) {
-    this.collapseLeftTimer = window.setTimeout(() => {
-      this.collapseLeftTimer = null;
-      // Re-check region from last known mouse position
-      if (this.currentRegion !== 'left') {
-        this.collapseSidebar(this.leftSidebar);
-      }
-    }, this.settings.sidebarDelay ?? 0);
-  }
-}
-// On entering left region, cancel pending collapse:
-if (inLeftRegion && this.collapseLeftTimer) {
-  clearTimeout(this.collapseLeftTimer);
-  this.collapseLeftTimer = null;
-}
-```
-
-For expand-on-hover, the collapse delay is 0 (instant). For quick-peek-sidebar, it's `settings.sidebarDelay` (default 150ms).
+**The `hovered` CSS class**: toggle inside `expandSidebar()` / `collapseSidebar()` instead of on mouseenter/mouseleave.
 
 ## Implementation order
 
-1. **sidebar-expand-on-hover**: Rewrite `setEvents` with coordinate-based mousemove. Remove hover flags, rootSplit handler, sidebar mouseenter/mouseleave. Keep ribbon/resize triggers and pin toggles.
-2. **quick-peek-sidebar**: Rewrite `onLayoutReady` rootSplit handler and `attachManualEvents` leave handlers. Remove trigger zone element. Keep ribbon/container mouseenter for CSS class and expand trigger. Replace leave handlers with coordinate-based collapse.
+1. **sidebar-expand-on-hover**: Rewrite `setEvents` with unified coordinate-based mousemove. Remove all hover flags, hover handlers, rootSplit handler, ribbon dblclick. Add toggle button click handlers. Keep resize handle and document mouseleave.
+2. **quick-peek-sidebar**: Same mousemove rewrite. Remove trigger zone element, all container mouseenter/mouseleave, ribbon handlers. Add toggle button click handlers. Move `hovered` class management into expand/collapse methods.
 3. Build and test both.
 4. Amend commits, force-push, rerelease.

--- a/coordinate-based-sidebar-hover-67fd03.md
+++ b/coordinate-based-sidebar-hover-67fd03.md
@@ -1,0 +1,166 @@
+# Coordinate-based sidebar hover architecture
+
+Replace all mouseenter/mouseleave/elementFromPoint sidebar detection with a single `document.mousemove` handler that uses coordinate math against stored sidebar sizes to determine which region the mouse is in.
+
+## Key discovery
+
+Obsidian stores `leftSplit.size` and `rightSplit.size` (e.g. 325) even when sidebars are collapsed (`display: none; width: 0px`). Combined with `leftRibbon.containerEl.getBoundingClientRect().right` (44px) and `workspace.containerEl.clientWidth` (full window), we can define stable rectangular regions that never depend on sidebar DOM state.
+
+## Region definitions
+
+```
+|  ribbon  |     left sidebar region     |        editor        |    right sidebar region    |
+0         44                            369                   1027                          1352
+           ribbonRight              ribbonRight+leftSize   wsWidth-rightSize            wsWidth
+```
+
+The right ribbon is collapsed (width 0) in Obsidian, so it doesn't affect layout.
+
+## Architecture (shared by both plugins)
+
+### Single mousemove handler (rAF-throttled)
+
+One `document.mousemove` listener, gated by `requestAnimationFrame` for perf:
+
+1. Compute `ribbonRight`, `leftSize`, `rightSize`, `wsWidth` on each frame
+2. Determine region: `left` | `editor` | `right` based on `event.clientX`
+3. On region transition (tracked via `currentRegion` field):
+   - **Entering left region** -> expand left sidebar
+   - **Entering right region** -> expand right sidebar  
+   - **Leaving left region** -> collapse left sidebar (after delay if configured)
+   - **Leaving right region** -> collapse right sidebar (after delay if configured)
+4. No-op if region unchanged
+
+### Modal/menu handling
+
+Instead of checking `isModalOrMenuOpen()` on every mousemove, **freeze the current region** when a modal/menu opens. This prevents any expand/collapse while the modal is active, without per-frame DOM queries:
+
+- Use a `MutationObserver` on `document.body` watching for `.modal-container` / `.menu` additions/removals
+- When modal opens: set `frozen = true`, record current sidebar states
+- When modal closes: set `frozen = false`, re-evaluate region from last known mouse position
+- The mousemove handler early-returns when `frozen`
+
+Alternative (simpler): just skip collapse/expand actions when `isModalOrMenuOpen()` returns true. The check is a single `querySelector` call, which is cheap. The MutationObserver approach avoids even that, but adds complexity. **I'd go with the simpler approach unless perf is a concern.**
+
+### What gets removed
+
+- All `mouseenter`/`mouseleave` handlers on sidebar containers, ribbons, and rootSplit
+- All hover tracking flags (`isHoveringLeftRegion`, `isHoveringRightRegion`, `isHoveringLeft`, `isHoveringRight`)
+- All `elementFromPoint` calls
+- All CSS selector matching on `relatedTarget` / `event.target`
+- The right trigger zone DOM element (quick-peek-sidebar) -- coordinate check replaces it
+- The `isRightEdgeHovering` flag (expand-on-hover) -- region transition replaces it
+
+### What stays
+
+- **Ribbon mouseenter** for left sidebar expansion trigger (expand-on-hover only -- it doesn't use the coordinate approach for initial trigger, only for deciding when to collapse)
+- **Pin/dblclick** handlers
+- **document mouseleave** (window exit -> collapse both)
+- **Resize handle mouseenter** for saving width on drag
+- **document click** handler (quick-peek-sidebar)
+- **layout-change** handler (quick-peek-sidebar)
+- All settings, hotkey commands, CSS variables, overlay mode
+
+Wait -- actually, if we're doing full coordinate-based monitoring, the ribbon mouseenter is redundant. The mousemove handler already detects "mouse entered left region" and expands. The ribbon mouseenter handler is only needed if we want expansion *only* from the ribbon (not from the full sidebar region). 
+
+**Decision point**: Should expansion trigger when the mouse enters *any* part of the left region (x < ribbonRight + leftSize), or only when it enters the ribbon strip (x < ribbonRight)?
+
+For **expand-on-hover**: the original behavior is ribbon-only trigger. But the user wants the sidebar to stay open when hovering its content area. So: **expand when entering the ribbon OR when the sidebar is already expanded and mouse stays in its region. Collapse only when mouse leaves the region.**
+
+This simplifies to: track whether the sidebar is expanded via `leftSplit.collapsed`. If the mouse is in the left region AND sidebar is collapsed, only expand from the ribbon trigger. If the mouse is in the left region AND sidebar is expanded, keep it open. If the mouse leaves the left region AND sidebar is expanded, collapse it.
+
+For **quick-peek-sidebar**: similar, but it has configurable pixel triggers (e.g. 20px from left edge) and expand delays.
+
+## Plugin-specific changes
+
+### sidebar-expand-on-hover
+
+**setEvents rewrite:**
+
+```
+ribbon mouseenter -> expandSidebar (existing trigger, unchanged)
+resize handle mouseenter -> expandSidebar + save size (unchanged)
+document mousemove (rAF-throttled):
+  - compute regions from leftSplit.size, rightSplit.size, ribbon rect, wsWidth
+  - if mouse NOT in left region AND left sidebar is expanded AND not pinned -> collapse left
+  - if mouse NOT in right region AND right sidebar is expanded AND not pinned -> collapse right
+  - if mouse near right edge (< RIGHT_EDGE_TRIGGER_PX from wsWidth) -> expand right
+  - skip all if isModalOrMenuOpen()
+document mouseleave -> collapse both (unchanged)
+ribbon dblclick -> toggle pin (unchanged)
+```
+
+**Remove entirely:**
+- rootSplit mouseenter handler
+- All mouseenter/mouseleave on leftSidebar, rightSidebar, leftRibbon, rightRibbon (hover tracking)
+- `isHoveringLeftRegion`, `isHoveringRightRegion`, `isRightEdgeHovering` flags
+
+### quick-peek-sidebar
+
+**onLayoutReady rewrite:**
+
+```
+document mousemove (rAF-throttled):
+  - compute regions (same math, using leftSplit.size, rightSplit.size)
+  - if mouse NOT in left region AND left not pinned AND not isActivelyEditing() -> schedule collapseLeft (with sidebarDelay)
+  - if mouse NOT in right region AND right not pinned AND not isActivelyEditing() -> schedule collapseRight (with sidebarDelay)
+  - skip all if onlyWhenFocused && !document.hasFocus()
+document mouseleave -> collapse both (unchanged)
+document click -> collapse on editor click (unchanged)
+```
+
+**attachManualEvents rewrite:**
+
+Keep:
+- leftRibbonMouseEnterHandler (ribbon trigger for left sidebar)
+- leftSplit.containerEl mouseenter -> set isHoveringLeft, add 'hovered' class, trigger expand if collapsed (this is still needed for CSS animation class)
+- rightSplit.containerEl mouseenter -> same for right
+- resize handle mouseenter triggers
+
+Change:
+- Remove `leftSplitMouseLeaveHandler` and `rightSplitMouseLeaveHandler` entirely -- collapse is now handled by the coordinate-based mousemove
+- Remove the right trigger zone DOM element -- coordinate check replaces it
+
+Remove:
+- rootSplit mouseenter handler
+
+**The `hovered` CSS class**: quick-peek-sidebar uses this class for CSS transitions. We can add it when expanding and remove it when collapsing, instead of on mouseenter/mouseleave. This decouples it from DOM events.
+
+## Collapse delay handling
+
+Both plugins support configurable collapse delays. With the coordinate approach:
+
+1. When mouse leaves a region, start a collapse timer
+2. If mouse re-enters the region before the timer fires, cancel it
+3. The timer callback checks the region again before collapsing
+
+```ts
+private collapseLeftTimer: number | null = null;
+
+// In mousemove, on leaving left region:
+if (!inLeftRegion && !leftSplit.collapsed && !pinned) {
+  if (!this.collapseLeftTimer) {
+    this.collapseLeftTimer = window.setTimeout(() => {
+      this.collapseLeftTimer = null;
+      // Re-check region from last known mouse position
+      if (this.currentRegion !== 'left') {
+        this.collapseSidebar(this.leftSidebar);
+      }
+    }, this.settings.sidebarDelay ?? 0);
+  }
+}
+// On entering left region, cancel pending collapse:
+if (inLeftRegion && this.collapseLeftTimer) {
+  clearTimeout(this.collapseLeftTimer);
+  this.collapseLeftTimer = null;
+}
+```
+
+For expand-on-hover, the collapse delay is 0 (instant). For quick-peek-sidebar, it's `settings.sidebarDelay` (default 150ms).
+
+## Implementation order
+
+1. **sidebar-expand-on-hover**: Rewrite `setEvents` with coordinate-based mousemove. Remove hover flags, rootSplit handler, sidebar mouseenter/mouseleave. Keep ribbon/resize triggers and pin toggles.
+2. **quick-peek-sidebar**: Rewrite `onLayoutReady` rootSplit handler and `attachManualEvents` leave handlers. Remove trigger zone element. Keep ribbon/container mouseenter for CSS class and expand trigger. Replace leave handlers with coordinate-based collapse.
+3. Build and test both.
+4. Amend commits, force-push, rerelease.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "This Obsidian plugin expands or collapses the sidebars based on mouse hovering on the ribbons.",
   "main": "main.js",
+  "type": "module",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js --environment BUILD:production"
@@ -11,13 +12,13 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^18.0.0",
-    "@rollup/plugin-node-resolve": "^11.2.1",
-    "@rollup/plugin-typescript": "^8.2.1",
-    "@types/node": "^14.14.37",
-    "obsidian": "^0.12.0",
-    "rollup": "^2.32.1",
-    "tslib": "^2.2.0",
-    "typescript": "^4.2.4"
+    "@rollup/plugin-commonjs": "^29.0.0",
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-typescript": "^12.0.0",
+    "@types/node": "^22.0.0",
+    "obsidian": "latest",
+    "rollup": "^4.0.0",
+    "tslib": "^2.8.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,5 +21,5 @@ export default {
     banner,
   },
   external: ['obsidian'],
-  plugins: [typescript(), nodeResolve({ browser: true }), commonjs()],
+  plugins: [typescript({ compilerOptions: { outDir: './build' } }), nodeResolve({ browser: true }), commonjs()],
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,8 +9,8 @@ interface SidebarExpandOnHoverSettings {
 }
 
 const DEFAULT_SETTINGS: SidebarExpandOnHoverSettings = {
-  leftSidebarWidth: 252,
-  rightSidebarWidth: 252,
+  leftSidebarWidth: 325,
+  rightSidebarWidth: 325,
   leftPin: false,
   rightPin: false,
   leftSideEnabled: true,
@@ -24,6 +24,12 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
   leftSidebar: HTMLElement;
   rightSidebar: HTMLElement;
   isRightEdgeHovering = false;
+
+  // Hover tracking flags — set by mouseenter/mouseleave on the actual
+  // container elements. These are stable across child-element transitions
+  // (mouseenter/mouseleave don't fire when moving between children).
+  private isHoveringLeftRegion = false;
+  private isHoveringRightRegion = false;
 
   private readonly RIGHT_EDGE_TRIGGER_PX = 20;
 
@@ -101,54 +107,40 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
 
   // Adds event listeners to the HTML elements
   setEvents: Function = () => {
-    this.registerDomEvent(document, 'mouseleave', () => {
-      this.collapseSidebar(this.leftSidebar);
-      this.collapseSidebar(this.rightSidebar);
+    // ── Hover tracking ──────────────────────────────────────────────
+    // mouseenter/mouseleave on a container are stable: they do NOT fire
+    // when moving between children (tab buttons, gaps, icons, etc.).
+    // We track both the sidebar split and its ribbon as one "region".
+
+    this.registerDomEvent(this.leftSidebar, 'mouseenter', () => {
+      this.isHoveringLeftRegion = true;
+    });
+    this.registerDomEvent(this.leftSidebar, 'mouseleave', () => {
+      this.isHoveringLeftRegion = false;
+    });
+    this.registerDomEvent(this.leftRibbon, 'mouseenter', () => {
+      this.isHoveringLeftRegion = true;
+    });
+    this.registerDomEvent(this.leftRibbon, 'mouseleave', () => {
+      this.isHoveringLeftRegion = false;
     });
 
-    this.registerDomEvent(
-      (this.app.workspace.rootSplit as any).containerEl,
-      'mouseenter',
-      () => {
-        this.isRightEdgeHovering = false;
-        this.collapseSidebar(this.leftSidebar);
-        this.collapseSidebar(this.rightSidebar);
-      }
-    );
-
-    this.registerDomEvent(document, 'mousemove', (event: MouseEvent) => {
-      if (this.settings.rightPin || !this.settings.rightSideEnabled) {
-        this.isRightEdgeHovering = false;
-        return;
-      }
-
-      if (this.isModalOrMenuOpen()) {
-        this.isRightEdgeHovering = false;
-        return;
-      }
-
-      const mouseX = event.clientX;
-      const editorWidth = this.app.workspace.containerEl.clientWidth;
-      const isNearRightEdge =
-        mouseX >= editorWidth - this.RIGHT_EDGE_TRIGGER_PX;
-
-      if (isNearRightEdge) {
-        this.isRightEdgeHovering = true;
-        this.expandSidebar(this.rightSidebar);
-        return;
-      }
-
-      if (this.isRightEdgeHovering) {
-        this.isRightEdgeHovering = false;
-      }
-
-      const target = event.target as HTMLElement | null;
-      if (target && this.rightSidebar?.contains(target)) {
-        return;
-      }
-
-      this.collapseSidebar(this.rightSidebar);
+    this.registerDomEvent(this.rightSidebar, 'mouseenter', () => {
+      this.isHoveringRightRegion = true;
     });
+    this.registerDomEvent(this.rightSidebar, 'mouseleave', () => {
+      this.isHoveringRightRegion = false;
+    });
+    if (this.rightRibbon) {
+      this.registerDomEvent(this.rightRibbon, 'mouseenter', () => {
+        this.isHoveringRightRegion = true;
+      });
+      this.registerDomEvent(this.rightRibbon, 'mouseleave', () => {
+        this.isHoveringRightRegion = false;
+      });
+    }
+
+    // ── Expand triggers ─────────────────────────────────────────────
 
     this.registerDomEvent(this.leftRibbon, 'mouseenter', () => {
       if (!this.settings.leftPin) {
@@ -164,7 +156,6 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
       });
     }
 
-    // To avoid 'glitch'
     this.registerDomEvent(
       (this.app.workspace.leftSplit as any).resizeHandleEl,
       'mouseenter',
@@ -192,7 +183,61 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
       }
     );
 
-    // Double click on left ribbon to toggle pin/unpin of left sidebar
+    // Right-edge mousemove trigger (right sidebar has no always-visible
+    // ribbon, so we detect proximity to the right edge of the workspace).
+    this.registerDomEvent(document, 'mousemove', (event: MouseEvent) => {
+      if (this.settings.rightPin || !this.settings.rightSideEnabled) {
+        this.isRightEdgeHovering = false;
+        return;
+      }
+
+      if (this.isModalOrMenuOpen()) {
+        this.isRightEdgeHovering = false;
+        return;
+      }
+
+      const mouseX = event.clientX;
+      const editorWidth = this.app.workspace.containerEl.clientWidth;
+      const isNearRightEdge =
+        mouseX >= editorWidth - this.RIGHT_EDGE_TRIGGER_PX;
+
+      if (isNearRightEdge) {
+        this.isRightEdgeHovering = true;
+        this.expandSidebar(this.rightSidebar);
+        return;
+      }
+
+      if (this.isRightEdgeHovering) {
+        this.isRightEdgeHovering = false;
+        if (!this.isHoveringRightRegion) {
+          this.collapseSidebar(this.rightSidebar);
+        }
+      }
+    });
+
+    // ── Collapse triggers ───────────────────────────────────────────
+
+    this.registerDomEvent(
+      (this.app.workspace.rootSplit as any).containerEl,
+      'mouseenter',
+      () => {
+        if (!this.isHoveringLeftRegion) {
+          this.collapseSidebar(this.leftSidebar);
+        }
+        if (!this.isHoveringRightRegion) {
+          this.isRightEdgeHovering = false;
+          this.collapseSidebar(this.rightSidebar);
+        }
+      }
+    );
+
+    this.registerDomEvent(document, 'mouseleave', () => {
+      this.collapseSidebar(this.leftSidebar);
+      this.collapseSidebar(this.rightSidebar);
+    });
+
+    // ── Pin toggles ─────────────────────────────────────────────────
+
     this.registerDomEvent(this.leftRibbon, 'dblclick', () => {
       if (this.settings.leftSideEnabled) {
         this.settings.leftPin = !this.settings.leftPin;
@@ -200,7 +245,6 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
       }
     });
 
-    // Double click on right ribbon to toggle pin/unpin of right sidebar
     if (this.rightRibbon) {
       this.registerDomEvent(this.rightRibbon, 'dblclick', () => {
         if (this.settings.rightSideEnabled) {
@@ -316,7 +360,7 @@ class SidebarExpandOnHoverSettingTab extends PluginSettingTab {
     leftSidebarWidth.setDesc('Set the width of left sidebar in pixel unit');
     leftSidebarWidth.addText((t) => {
       t.setValue(String(this.plugin.settings.leftSidebarWidth));
-      t.setPlaceholder('Default: 252').onChange(async (value) => {
+      t.setPlaceholder('Default: 325').onChange(async (value) => {
         this.plugin.settings.leftSidebarWidth = Number(value);
         (this.app.workspace.leftSplit as any).setSize(
           this.plugin.settings.leftSidebarWidth
@@ -330,7 +374,7 @@ class SidebarExpandOnHoverSettingTab extends PluginSettingTab {
     rightSidebarWidth.setDesc('Set the width of right sidebar in pixel unit');
     rightSidebarWidth.addText((t) => {
       t.setValue(String(this.plugin.settings.rightSidebarWidth));
-      t.setPlaceholder('Default: 252').onChange(async (value) => {
+      t.setPlaceholder('Default: 325').onChange(async (value) => {
         this.plugin.settings.rightSidebarWidth = Number(value);
         (this.app.workspace.rightSplit as any).setSize(
           this.plugin.settings.rightSidebarWidth

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,9 +20,12 @@ const DEFAULT_SETTINGS: SidebarExpandOnHoverSettings = {
 export default class SidebarExpandOnHoverPlugin extends Plugin {
   settings: SidebarExpandOnHoverSettings;
   leftRibbon: HTMLElement;
-  rightRibbon: HTMLElement;
+  rightRibbon?: HTMLElement;
   leftSidebar: HTMLElement;
   rightSidebar: HTMLElement;
+  isRightEdgeHovering = false;
+
+  private readonly RIGHT_EDGE_TRIGGER_PX = 20;
 
   async onload() {
     // Initialize and set events when layout is fully ready
@@ -83,11 +86,17 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
   // Initializes the variables to store DOM HTML elements
   initialize: Function = () => {
     this.leftRibbon = (this.app.workspace.leftRibbon as any).containerEl;
-    this.rightRibbon = (this.app.workspace.rightRibbon as any).containerEl;
+    this.rightRibbon = (this.app.workspace.rightRibbon as any)?.containerEl;
     this.leftSidebar = ((this.app.workspace
       .leftSplit as unknown) as any).containerEl;
     this.rightSidebar = ((this.app.workspace
       .rightSplit as unknown) as any).containerEl;
+  };
+
+  isModalOrMenuOpen = (): boolean => {
+    const hasModal = document.querySelector('.modal-container') !== null;
+    const hasMenu = document.querySelector('.menu') !== null;
+    return hasModal || hasMenu;
   };
 
   // Adds event listeners to the HTML elements
@@ -101,10 +110,45 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
       (this.app.workspace.rootSplit as any).containerEl,
       'mouseenter',
       () => {
+        this.isRightEdgeHovering = false;
         this.collapseSidebar(this.leftSidebar);
         this.collapseSidebar(this.rightSidebar);
       }
     );
+
+    this.registerDomEvent(document, 'mousemove', (event: MouseEvent) => {
+      if (this.settings.rightPin || !this.settings.rightSideEnabled) {
+        this.isRightEdgeHovering = false;
+        return;
+      }
+
+      if (this.isModalOrMenuOpen()) {
+        this.isRightEdgeHovering = false;
+        return;
+      }
+
+      const mouseX = event.clientX;
+      const editorWidth = this.app.workspace.containerEl.clientWidth;
+      const isNearRightEdge =
+        mouseX >= editorWidth - this.RIGHT_EDGE_TRIGGER_PX;
+
+      if (isNearRightEdge) {
+        this.isRightEdgeHovering = true;
+        this.expandSidebar(this.rightSidebar);
+        return;
+      }
+
+      if (this.isRightEdgeHovering) {
+        this.isRightEdgeHovering = false;
+      }
+
+      const target = event.target as HTMLElement | null;
+      if (target && this.rightSidebar?.contains(target)) {
+        return;
+      }
+
+      this.collapseSidebar(this.rightSidebar);
+    });
 
     this.registerDomEvent(this.leftRibbon, 'mouseenter', () => {
       if (!this.settings.leftPin) {
@@ -112,11 +156,13 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
       }
     });
 
-    this.registerDomEvent(this.rightRibbon, 'mouseenter', () => {
-      if (!this.settings.rightPin) {
-        this.expandSidebar(this.rightSidebar);
-      }
-    });
+    if (this.rightRibbon) {
+      this.registerDomEvent(this.rightRibbon, 'mouseenter', () => {
+        if (!this.settings.rightPin) {
+          this.expandSidebar(this.rightSidebar);
+        }
+      });
+    }
 
     // To avoid 'glitch'
     this.registerDomEvent(
@@ -155,12 +201,14 @@ export default class SidebarExpandOnHoverPlugin extends Plugin {
     });
 
     // Double click on right ribbon to toggle pin/unpin of right sidebar
-    this.registerDomEvent(this.rightRibbon, 'dblclick', () => {
-      if (this.settings.rightSideEnabled) {
-        this.settings.rightPin = !this.settings.rightPin;
-        this.saveSettings();
-      }
-    });
+    if (this.rightRibbon) {
+      this.registerDomEvent(this.rightRibbon, 'dblclick', () => {
+        if (this.settings.rightSideEnabled) {
+          this.settings.rightPin = !this.settings.rightPin;
+          this.saveSettings();
+        }
+      });
+    }
   };
 
   // Changes sidebar style width and display to expand it

--- a/workspace.html
+++ b/workspace.html
@@ -1,0 +1,3227 @@
+<div class="app-container">
+    <div class="horizontal-main-container">
+        <div class="workspace is-left-sidedock-open is-right-sidedock-open" style="position: relative;">
+            <div class="workspace-ribbon side-dock-ribbon mod-left">
+                <div class="side-dock-actions">
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open quick switcher"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-file-search">
+                            <path
+                                d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z">
+                            </path>
+                            <path d="M14 2v5a1 1 0 0 0 1 1h5"></path>
+                            <circle cx="11.5" cy="14.5" r="2.5"></circle>
+                            <path d="M13.3 16.3 15 18"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open graph view"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-git-fork">
+                            <circle cx="12" cy="18" r="3"></circle>
+                            <circle cx="6" cy="6" r="3"></circle>
+                            <circle cx="18" cy="6" r="3"></circle>
+                            <path d="M18 9v2c0 .6-.4 1-1 1H7c-.6 0-1-.4-1-1V9"></path>
+                            <path d="M12 12v3"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Create new canvas"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-layout-dashboard">
+                            <rect x="3" y="3" width="7" height="9" rx="1"></rect>
+                            <rect x="14" y="3" width="7" height="5" rx="1"></rect>
+                            <rect x="14" y="12" width="7" height="9" rx="1"></rect>
+                            <rect x="3" y="16" width="7" height="5" rx="1"></rect>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open today's daily note"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-calendar">
+                            <path d="M8 2v4"></path>
+                            <path d="M16 2v4"></path>
+                            <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+                            <path d="M3 10h18"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Insert template"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-files">
+                            <path d="M15 2h-4a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8"></path>
+                            <path d="M16.706 2.706A2.4 2.4 0 0 0 15 2v5a1 1 0 0 0 1 1h5a2.4 2.4 0 0 0-.706-1.706z">
+                            </path>
+                            <path d="M5 7a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h8a2 2 0 0 0 1.732-1"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open command palette"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-terminal">
+                            <path d="M12 19h8"></path>
+                            <path d="m4 17 6-6-6-6"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Create new base"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-layout-list">
+                            <rect x="3" y="3" width="7" height="7" rx="1"></rect>
+                            <rect x="3" y="14" width="7" height="7" rx="1"></rect>
+                            <path d="M14 4h7"></path>
+                            <path d="M14 9h7"></path>
+                            <path d="M14 15h7"></path>
+                            <path d="M14 20h7"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon"
+                        aria-label="Manage workspace layouts" data-tooltip-position="right" data-tooltip-delay="300">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-layout">
+                            <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+                            <path d="M3 9h18"></path>
+                            <path d="M9 21V9"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon"
+                        aria-label="Smart Connections: Open connections view" data-tooltip-position="right"
+                        data-tooltip-delay="300"><svg viewBox="0 0 100 100" class="svg-icon smart-connections">
+                            <path d="M50,20 L80,40 L80,60 L50,100" stroke="currentColor" stroke-width="4" fill="none">
+                            </path>
+                            <path d="M30,50 L55,70" stroke="currentColor" stroke-width="5" fill="none"></path>
+                            <circle cx="50" cy="20" r="9" fill="currentColor"></circle>
+                            <circle cx="80" cy="40" r="9" fill="currentColor"></circle>
+                            <circle cx="80" cy="70" r="9" fill="currentColor"></circle>
+                            <circle cx="50" cy="100" r="9" fill="currentColor"></circle>
+                            <circle cx="30" cy="50" r="9" fill="currentColor"></circle>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon"
+                        aria-label="Smart Lookup: Open lookup view" data-tooltip-position="right"
+                        data-tooltip-delay="300"><svg viewBox="0 0 100 100" class="svg-icon smart-lookup">
+                            <defs>
+                                <clipPath id="sc-in-search-clip" clipPathUnits="userSpaceOnUse">
+                                    <circle cx="11" cy="11" r="8"></circle>
+                                </clipPath>
+                                <symbol id="smart-lookup-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                    stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+                                    <g clip-path="url(#sc-in-search-clip)">
+                                        <path d="M10.3,5.4 L14.5,8.2 L14.5,11.0 L10.3,16.6" stroke="currentColor"
+                                            stroke-width="0.56" fill="none"></path>
+                                        <path d="M7.5,9.6 L11.0,12.4" stroke="currentColor" stroke-width="0.7"
+                                            fill="none"></path>
+                                        <circle cx="10.3" cy="5.4" r="0.3" fill="currentColor"></circle>
+                                        <circle cx="14.5" cy="8.2" r="0.3" fill="currentColor"></circle>
+                                        <circle cx="14.5" cy="12.4" r="0.3" fill="currentColor"></circle>
+                                        <circle cx="10.3" cy="16.6" r="0.3" fill="currentColor"></circle>
+                                        <circle cx="7.5" cy="9.6" r="0.3" fill="currentColor"></circle>
+                                    </g>
+                                    <circle cx="11" cy="11" r="8"></circle>
+                                    <path d="m21 21-4.3-4.3"></path>
+                                </symbol>
+                            </defs>
+                            <use href="#smart-lookup-icon"></use>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon"
+                        aria-label="Smart Connections: Open random connection" data-tooltip-position="right"
+                        data-tooltip-delay="300"><svg viewBox="0 0 100 100" class="svg-icon smart-dice"><svg
+                                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor"
+                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="1" y="1" width="22" height="22" rx="2" fill="none"></rect>
+
+                                <g transform="translate(12 10) scale(0.18) translate(-50 -50)">
+                                    <path d="M50 20 L80 40 L80 60 L50 100" fill="none" stroke="currentColor"
+                                        stroke-width="4"></path>
+                                    <path d="M30 50 L55 70" fill="none" stroke="currentColor" stroke-width="5"></path>
+                                    <circle cx="50" cy="20" r="9" fill="currentColor"></circle>
+                                    <circle cx="75" cy="40" r="9" fill="currentColor"></circle>
+                                    <circle cx="75" cy="70" r="9" fill="currentColor"></circle>
+                                    <circle cx="50" cy="100" r="9" fill="currentColor"></circle>
+                                    <circle cx="25" cy="50" r="9" fill="currentColor"></circle>
+                                </g>
+                            </svg>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open Importer"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-import">
+                            <path d="M12 3v12"></path>
+                            <path d="m8 11 4 4 4-4"></path>
+                            <path d="M8 5H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-4"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="BRAT"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg viewBox="0 0 100 100"
+                            class="svg-icon BratIcon">
+                            <path fill="currentColor" stroke="currentColor"
+                                d="M 41.667969 41.667969 C 41.667969 39.367188 39.800781 37.5 37.5 37.5 C 35.199219 37.5 33.332031 39.367188 33.332031 41.667969 C 33.332031 43.96875 35.199219 45.832031 37.5 45.832031 C 39.800781 45.832031 41.667969 43.96875 41.667969 41.667969 Z M 60.417969 58.582031 C 59.460938 58.023438 58.320312 57.867188 57.25 58.148438 C 56.179688 58.429688 55.265625 59.125 54.707031 60.082031 C 53.746094 61.777344 51.949219 62.820312 50 62.820312 C 48.050781 62.820312 46.253906 61.777344 45.292969 60.082031 C 44.734375 59.125 43.820312 58.429688 42.75 58.148438 C 41.679688 57.867188 40.539062 58.023438 39.582031 58.582031 C 37.597656 59.726562 36.910156 62.257812 38.042969 64.25 C 40.5 68.53125 45.0625 71.171875 50 71.171875 C 54.9375 71.171875 59.5 68.53125 61.957031 64.25 C 63.089844 62.257812 62.402344 59.726562 60.417969 58.582031 Z M 62.5 37.5 C 60.199219 37.5 58.332031 39.367188 58.332031 41.667969 C 58.332031 43.96875 60.199219 45.832031 62.5 45.832031 C 64.800781 45.832031 66.667969 43.96875 66.667969 41.667969 C 66.667969 39.367188 64.800781 37.5 62.5 37.5 Z M 50 8.332031 C 26.988281 8.332031 8.332031 26.988281 8.332031 50 C 8.332031 73.011719 26.988281 91.667969 50 91.667969 C 73.011719 91.667969 91.667969 73.011719 91.667969 50 C 91.667969 26.988281 73.011719 8.332031 50 8.332031 Z M 50 83.332031 C 33.988281 83.402344 20.191406 72.078125 17.136719 56.363281 C 14.078125 40.644531 22.628906 24.976562 37.5 19.042969 C 37.457031 19.636719 37.457031 20.238281 37.5 20.832031 C 37.5 27.738281 43.097656 33.332031 50 33.332031 C 52.300781 33.332031 54.167969 31.46875 54.167969 29.167969 C 54.167969 26.867188 52.300781 25 50 25 C 47.699219 25 45.832031 23.132812 45.832031 20.832031 C 45.832031 18.53125 47.699219 16.667969 50 16.667969 C 68.410156 16.667969 83.332031 31.589844 83.332031 50 C 83.332031 68.410156 68.410156 83.332031 50 83.332031 Z M 50 83.332031 ">
+                            </path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open format converter"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-binary">
+                            <rect x="14" y="14" width="4" height="6" rx="2"></rect>
+                            <rect x="6" y="4" width="4" height="6" rx="2"></rect>
+                            <path d="M6 20h4"></path>
+                            <path d="M14 10h4"></path>
+                            <path d="M6 14h2v6"></path>
+                            <path d="M14 4h2v6"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open rulebook"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-book-image">
+                            <path d="m20 13.7-2.1-2.1a2 2 0 0 0-2.8 0L9.7 17"></path>
+                            <path
+                                d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20">
+                            </path>
+                            <circle cx="10" cy="8" r="2"></circle>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open Git source control"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-git-pull-request">
+                            <circle cx="18" cy="18" r="3"></circle>
+                            <circle cx="6" cy="6" r="3"></circle>
+                            <path d="M13 6h3a2 2 0 0 1 2 2v7"></path>
+                            <line x1="6" y1="9" x2="6" y2="21"></line>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="SQLSeal Explorer"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg viewBox="0 0 100 100"
+                            class="svg-icon logo-sqlseal"><!--?xml version="1.0" encoding="UTF-8" standalone="no"?-->
+                            <svg width="100%" height="100%" viewBox="0 0 91 91" version="1.1"
+                                xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xml:space="preserve" xmlns:serif="http://www.serif.com/"
+                                style="fill-rule:evenodd;clip-rule:evenodd;" fill="none" stroke="currentColor"
+                                stroke-width="2" class="svg-icon">
+                                <g>
+                                    <path fill="currentColor" stroke="none"
+                                        d="M76.595,73.106c-1.409,-1.318 -2.846,-2.451 -3.7,-3.097c0.15,-2.473 -0.239,-4.9 -1.171,-7.268c-1.962,-4.986 -5.948,-8.893 -9.201,-11.739c-4.354,-3.81 -3.922,-9.686 -3.276,-12.851c0.361,-1.785 -0.072,-3.6 -1.135,-4.999c-0.904,-1.189 -5.401,-2.873 -8.602,-1.632c-5.254,2.037 -8.97,4.302 -10.802,7.457c-1.335,2.299 -1.688,4.865 -1.05,7.628c0.195,0.848 0.762,1.934 1.545,3.438c1.646,3.157 4.133,7.928 3.103,10.994c-0.354,1.055 -1.136,1.857 -2.391,2.451c-4.534,2.147 -6.793,-0.153 -9.977,-4.196c-1.169,-1.486 -2.275,-2.889 -3.594,-3.743c-1.806,-1.168 -4.117,-1.465 -6.683,-0.861c-1.208,0.284 -2.147,1.209 -2.45,2.413c-0.298,1.179 0.08,2.409 0.986,3.212c0.04,0.036 0.076,0.071 0.103,0.096c0.559,0.548 0.44,1.205 0.363,1.462c-0.172,0.576 -0.623,0.988 -1.205,1.102c-1.537,0.302 -3.123,0.813 -4.715,1.521c-1.778,0.794 -2.898,2.57 -2.852,4.523c0.045,1.958 1.2,3.616 3.012,4.328c2.315,0.908 5.277,1.412 8.804,1.496c1.952,0.047 3.731,0.966 4.882,2.521c0.407,0.55 0.842,1.085 1.296,1.604c-0.364,0.432 -0.745,0.869 -1.145,1.312c-1.141,1.263 -1.381,3.706 -0.875,4.627c2.044,3.717 13.868,2.571 16.224,0.599c0.113,-0.096 0.216,1.548 3.184,2.28c6.373,1.573 19.837,0.086 22.118,-5.228c1.11,0.221 3.056,0.571 5.076,0.749c0.749,0.067 1.563,0.119 2.38,0.119c2.589,-0 5.202,-0.522 5.841,-2.762c0.574,-2.005 -0.727,-4.407 -4.093,-7.556Zm-9.694,4.685c-2.685,4.59 -8.859,7.267 -15.731,7.457l-1.498,0c-1.877,-0.046 -3.789,-0.272 -5.684,-0.698c4.033,-2.439 6.299,-5.342 6.47,-5.565c0.562,-0.736 0.421,-1.788 -0.315,-2.35c-0.736,-0.562 -1.788,-0.421 -2.35,0.315c-0.067,0.087 -6.82,8.751 -17.855,7.5c-0.624,-0.071 -0.863,-0.534 -0.937,-0.73c-0.076,-0.2 -0.205,-0.716 0.226,-1.194c2.965,-3.281 4.995,-6.26 6.033,-8.854c0.344,-0.859 -0.074,-1.835 -0.934,-2.179c-0.86,-0.344 -1.835,0.074 -2.179,0.934c-0.459,1.147 -1.192,2.439 -2.166,3.829c-0.239,-0.291 -0.474,-0.586 -0.697,-0.888c-1.771,-2.393 -4.504,-3.807 -7.497,-3.879c-3.09,-0.073 -5.738,-0.511 -7.659,-1.265c-0.78,-0.306 -0.879,-1 -0.886,-1.284c-0.006,-0.232 0.041,-1.016 0.865,-1.384c1.36,-0.604 2.705,-1.039 3.995,-1.292c1.799,-0.353 3.245,-1.667 3.773,-3.432c0.515,-1.724 0.044,-3.57 -1.23,-4.818c-0.005,-0.005 -0.013,-0.012 -0.017,-0.017c-0.026,-0.024 -0.052,-0.049 -0.078,-0.074c1.626,-0.361 2.962,-0.213 3.972,0.441c0.851,0.55 1.789,1.741 2.782,3.002c2.695,3.424 6.77,8.598 14.045,5.152c2.093,-0.992 3.484,-2.477 4.135,-4.414c1.484,-4.418 -1.4,-9.951 -3.308,-13.611c-0.54,-1.036 -1.153,-2.211 -1.252,-2.642c-0.446,-1.934 -0.223,-3.631 0.682,-5.191c1.6,-2.754 5.234,-4.952 10.803,-6.53c0.882,-0.249 1.837,-0.042 2.548,0.551l0.049,0.041c0.799,0.665 1.165,1.723 0.954,2.76c-0.79,3.877 -1.276,11.116 4.354,16.042c2.968,2.596 6.592,6.13 8.289,10.444c1.728,4.389 1.171,8.911 -1.702,13.823Zm5.243,2.115c-0.85,-0.091 -1.677,-0.211 -2.404,-0.331c0.018,-0.03 0.037,-0.06 0.055,-0.091c1.124,-1.921 1.944,-3.827 2.463,-5.71c0.598,0.488 1.266,1.057 1.926,1.669c2.889,2.675 3.235,3.925 3.276,4.226c-0.275,0.16 -1.464,0.65 -5.316,0.237Z">
+                                    </path>
+                                    <circle cx="47.242" cy="39.859" r="1.676" fill="currentColor" stroke="none">
+                                    </circle>
+                                    <path
+                                        d="M76.42,14.232c-1.116,3.3 -7.37,4.166 -13.969,1.935c-6.598,-2.231 -11.044,-6.715 -9.928,-10.014c1.115,-3.3 7.369,-4.166 13.968,-1.935c6.599,2.231 11.044,6.715 9.929,10.014Z">
+                                    </path>
+                                    <path
+                                        d="M73.895,21.7c-1.116,3.299 -7.369,4.165 -13.968,1.934c-6.599,-2.231 -11.044,-6.714 -9.929,-10.014">
+                                    </path>
+                                    <path
+                                        d="M52.523,6.153l-5.05,14.935c-1.115,3.3 3.33,7.783 9.929,10.014c6.599,2.231 12.853,1.365 13.968,-1.934l5.05,-14.936">
+                                    </path>
+                                </g>
+                            </svg></svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open mini calendar"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-calendar-days">
+                            <path d="M8 2v4"></path>
+                            <path d="M16 2v4"></path>
+                            <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+                            <path d="M3 10h18"></path>
+                            <path d="M8 14h.01"></path>
+                            <path d="M12 14h.01"></path>
+                            <path d="M16 14h.01"></path>
+                            <path d="M8 18h.01"></path>
+                            <path d="M12 18h.01"></path>
+                            <path d="M16 18h.01"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open advanced calendar"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-calendar">
+                            <path d="M8 2v4"></path>
+                            <path d="M16 2v4"></path>
+                            <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+                            <path d="M3 10h18"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open task list"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-check-square">
+                            <path d="M21 10.656V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h12.344"></path>
+                            <path d="m9 11 3 3L22 4"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open agenda"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-list">
+                            <path d="M3 5h.01"></path>
+                            <path d="M3 12h.01"></path>
+                            <path d="M3 19h.01"></path>
+                            <path d="M8 5h13"></path>
+                            <path d="M8 12h13"></path>
+                            <path d="M8 19h13"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open kanban board"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-columns-3">
+                            <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+                            <path d="M9 3v18"></path>
+                            <path d="M15 3v18"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open pomodoro"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-timer">
+                            <line x1="10" y1="2" x2="14" y2="2"></line>
+                            <line x1="12" y1="14" x2="15" y2="11"></line>
+                            <circle cx="12" cy="14" r="8"></circle>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Open pomodoro stats"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg xmlns="http://www.w3.org/2000/svg"
+                            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="svg-icon lucide-bar-chart-3">
+                            <path d="M3 3v16a2 2 0 0 0 2 2h16"></path>
+                            <path d="M18 17V9"></path>
+                            <path d="M13 17V5"></path>
+                            <path d="M8 17v-3"></path>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Create new task"
+                        data-tooltip-position="right" data-tooltip-delay="300"><svg viewBox="0 0 100 100"
+                            class="svg-icon tasknotes-simple">
+                            <g>
+                                <defs>
+                                    <mask id="tasknotes-mask">
+                                        <rect width="100" height="100" fill="white"></rect>
+                                        <path fill="black"
+                                            d="m 5.9,52.4 -0.09,4.51 c 4.71,0.09 7.61,1.48 9.95,3.57 2.35,2.09 4.11,5.01 5.90,8.14 1.80,3.13 3.62,6.46 6.45,9.12 2.23,2.09 5.14,3.67 8.83,4.21 0.46,-1.51 1.05,-2.95 1.77,-4.33 -3.44,-0.21 -5.62,-1.39 -7.53,-3.17 -2.14,-2.01 -3.82,-4.92 -5.63,-8.08 -1.81,-3.16 -3.77,-6.56 -6.82,-9.27 -3.05,-2.71 -7.07,-4.59 -11.83,-4.70 z">
+                                        </path>
+                                        <path fill="black"
+                                            d="M 73.6,18.3 69.9,20.9 c 4.06,5.75 4.40,11.33 2.77,16.78 -1.63,5.45 -5.41,10.67 -9.65,14.78 -8.49,8.20 -16.59,14.11 -21.83,21.18 -5.24,7.07 -7.22,15.59 -3.13,27.21 l 4.25,-1.50 c -3.74,-10.62 -2.11,-16.80 2.50,-23.01 4.61,-6.21 12.63,-12.19 21.34,-20.64 4.65,-4.50 8.89,-10.23 10.84,-16.72 1.95,-6.49 1.42,-13.86 -3.40,-20.68 z">
+                                        </path>
+                                    </mask>
+                                </defs>
+                                <path fill="currentColor" mask="url(#tasknotes-mask)"
+                                    d="m 98.5,0.6 c -0.38,0 -0.83,0.09 -1.33,0.23 -2,0.59 -4.66,2.18 -5.78,3.22 -1.25,1.16 -4.16,4.93 -6.08,7.19 -2.67,3.12 -5.65,6.58 -9.32,11.13 2.58,5.61 2.61,11.38 1.05,16.60 -1.95,6.49 -6.19,12.22 -10.84,16.72 -8.71,8.43 -16.73,14.41 -21.34,20.64 -4.47,6.03 -6.13,12.03 -2.81,22.08 0.19,-0.23 0.37,-0.49 0.54,-0.80 10.57,-19.70 17.89,-27.30 41.9,-47.08 v 0 c 2.40,-1.97 3.71,-4.33 4.52,-7.14 0.81,-2.82 1.11,-6.10 1.52,-9.92 0.81,-7.64 2.02,-17.43 8.43,-29.95 0.37,-0.73 0.57,-1.30 0.62,-1.72 0.05,-0.43 -0.04,-0.71 -0.22,-0.90 -0.19,-0.18 -0.48,-0.27 -0.86,-0.26 z M 72.7,26.3 c -0.75,0.92 -1.51,1.84 -2.27,2.78 -9.09,11.05 -19.45,22.93 -28.54,29.97 -1.48,1.14 -2.98,1.54 -4.46,1.38 -1.49,-0.16 -2.97,-0.89 -4.43,-1.96 -2.91,-2.16 -5.74,-5.74 -8.35,-9.19 -2.62,-3.45 -5.04,-6.77 -7.12,-8.39 -1.04,-0.81 -1.99,-1.19 -2.83,-0.97 -0.84,0.22 -1.60,1.05 -2.26,2.70 -1.03,2.61 -1.60,6.22 -3.42,10.05 4.08,0.62 7.27,2.27 9.73,4.45 3.05,2.71 5.01,6.11 6.82,9.27 1.81,3.16 3.49,6.07 5.63,8.08 1.90,1.78 4.08,2.96 7.53,3.17 0.71,-1.37 1.55,-2.69 2.49,-3.95 5.24,-7.07 13.34,-12.98 21.83,-21.18 4.24,-4.11 8.02,-9.33 9.65,-14.78 1.12,-3.73 1.31,-7.53 0.01,-11.42 z M 10.3,49.1 c -0.09,0.29 -0.18,0.56 -0.28,0.85 0.10,-0.29 0.19,-0.56 0.28,-0.85 z m -4.02,7.84 c -0.01,0.01 -0.02,0.02 -0.03,0.03 0.01,-0.01 0.02,-0.02 0.03,-0.03 0,0 0,0 0,0 z m 0.12,0 c -1.08,1.40 -2.40,2.79 -4.05,4.12 -1.20,1.0 -1.85,1.86 -2.03,2.71 -0.18,0.85 0.10,1.67 0.76,2.53 1.32,1.71 4.16,3.54 7.81,5.91 7.28,4.73 17.75,11.63 25.63,24.16 0.64,1.02 1.74,2.04 2.95,2.65 -0.91,-5.36 -0.91,-8.78 -0.54,-11.88 -3.33,-0.55 -6.07,-2.12 -8.39,-4.72 -2.83,-3.17 -4.69,-6.59 -6.54,-9.85 -1.85,-3.26 -3.69,-6.37 -6.08,-8.47 -2.06,-1.81 -4.61,-3.0 -8.49,-3.17 z">
+                                </path>
+                            </g>
+                        </svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon" aria-label="Templater"
+                        data-tooltip-position="right" data-tooltip-delay="300" id="rb-templater-icon"><svg
+                            viewBox="0 0 100 100" class="svg-icon templater-icon"><svg
+                                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 51.1328 28.7">
+                                <path
+                                    d="M0 15.14 0 10.15 18.67 1.51 18.67 6.03 4.72 12.33 4.72 12.76 18.67 19.22 18.67 23.74 0 15.14ZM33.6928 1.84C33.6928 1.84 33.9761 2.1467 34.5428 2.76C35.1094 3.38 35.3928 4.56 35.3928 6.3C35.3928 8.0466 34.8195 9.54 33.6728 10.78C32.5261 12.02 31.0995 12.64 29.3928 12.64C27.6862 12.64 26.2661 12.0267 25.1328 10.8C23.9928 9.5733 23.4228 8.0867 23.4228 6.34C23.4228 4.6 23.9995 3.1066 25.1528 1.86C26.2994.62 27.7261 0 29.4328 0C31.1395 0 32.5594.6133 33.6928 1.84M49.8228.67 29.5328 28.38 24.4128 28.38 44.7128.67 49.8228.67M31.0328 8.38C31.0328 8.38 31.1395 8.2467 31.3528 7.98C31.5662 7.7067 31.6728 7.1733 31.6728 6.38C31.6728 5.5867 31.4461 4.92 30.9928 4.38C30.5461 3.84 29.9995 3.57 29.3528 3.57C28.7061 3.57 28.1695 3.84 27.7428 4.38C27.3228 4.92 27.1128 5.5867 27.1128 6.38C27.1128 7.1733 27.3361 7.84 27.7828 8.38C28.2361 8.9267 28.7861 9.2 29.4328 9.2C30.0795 9.2 30.6128 8.9267 31.0328 8.38M49.4328 17.9C49.4328 17.9 49.7161 18.2067 50.2828 18.82C50.8495 19.4333 51.1328 20.6133 51.1328 22.36C51.1328 24.1 50.5594 25.59 49.4128 26.83C48.2595 28.0766 46.8295 28.7 45.1228 28.7C43.4228 28.7 42.0028 28.0833 40.8628 26.85C39.7295 25.6233 39.1628 24.1366 39.1628 22.39C39.1628 20.65 39.7361 19.16 40.8828 17.92C42.0361 16.6733 43.4628 16.05 45.1628 16.05C46.8694 16.05 48.2928 16.6667 49.4328 17.9M46.8528 24.52C46.8528 24.52 46.9595 24.3833 47.1728 24.11C47.3795 23.8367 47.4828 23.3033 47.4828 22.51C47.4828 21.7167 47.2595 21.05 46.8128 20.51C46.3661 19.97 45.8162 19.7 45.1628 19.7C44.5161 19.7 43.9828 19.97 43.5628 20.51C43.1428 21.05 42.9328 21.7167 42.9328 22.51C42.9328 23.3033 43.1561 23.9733 43.6028 24.52C44.0494 25.06 44.5961 25.33 45.2428 25.33C45.8895 25.33 46.4261 25.06 46.8528 24.52Z"
+                                    fill="currentColor"></path>
+                            </svg></svg></div>
+                    <div class="clickable-icon side-dock-ribbon-action iconic-icon"
+                        aria-label="Open CSS editor quick switcher" data-tooltip-position="right"
+                        data-tooltip-delay="300"><svg viewBox="0 0 100 100" class="svg-icon css-editor-logo"><svg
+                                xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 1000 1000"
+                                role="img">
+                                <defs>
+                                    <mask id="css-editor-logo-cutout-mask">
+                                        <rect width="1000" height="1000" fill="white"></rect>
+                                        <path fill="black"
+                                            d="m358.1,920c-64.23-.06-103.86-36.23-103.1-102.79,0,0,0-168.39,0-168.39,0-33.74,9.88-59.4,29.64-76.96,35.49-34.19,117.83-36.27,152.59.52,21.42,18.89,29.5,57.48,27.58,93.49h-73.72c.56-14.15-.19-35.58-8.51-43.65-10.81-14.63-39.36-12.91-46.91,2.32-4.64,8.26-6.96,20.49-6.96,36.67v146.18c0,30.65,10.65,46.15,31.96,46.49,9.96,0,17.53-3.62,22.68-10.85,7.19-8.58,8.31-27.58,7.73-41.32h73.72c5.04,70.07-36.32,119.16-106.71,118.29Zm234.04,0c-71.17.98-103.01-49.66-101.04-118.29h69.59c-1.93,29.92,8.35,57.17,32.99,55.27,10.99,0,18.73-3.44,23.2-10.33,8.5-12.59,10.09-48.95-2.06-63.02-8.49-13.55-39.03-25.51-55.16-33.57-23.03-11.02-39.61-24.1-49.75-39.26-22.87-33.64-20.75-107.48,11.34-137.4,31.18-36.92,112.61-38.62,143.82-.77,19.25,19.51,27.66,57.9,26.03,93.23h-67.02c.57-14.52-.8-37.95-6.44-46.49-3.95-7.23-11.43-10.85-22.42-10.85-19.59,0-29.38,11.71-29.38,35.12.21,24.86,9.9,35.06,32.48,45.45,29.24,11.36,66.42,30.76,79.9,54.24,40.2,71.54,12.62,180.82-86.09,176.65Zm224.76,0c-71.17.98-103.01-49.66-101.04-118.29h69.59c-1.93,29.92,8.35,57.17,32.99,55.27,10.99,0,18.73-3.44,23.2-10.33,8.5-12.59,10.09-48.95-2.06-63.02-8.49-13.55-39.03-25.51-55.16-33.57-23.03-11.02-39.61-24.1-49.75-39.26-22.87-33.64-20.75-107.48,11.34-137.4,31.18-36.92,112.61-38.62,143.82-.77,19.25,19.51,27.66,57.9,26.03,93.23h-67.02c.57-14.52-.8-37.95-6.44-46.49-3.95-7.23-11.43-10.85-22.42-10.85-19.59,0-29.38,11.71-29.38,35.12.21,24.86,9.9,35.06,32.48,45.45,29.24,11.36,66.42,30.76,79.9,54.24,40.2,71.54,12.62,180.82-86.09,176.65Z">
+                                        </path>
+                                    </mask>
+                                </defs>
+                                <path fill="currentColor" mask="url(#css-editor-logo-cutout-mask)"
+                                    d="M0 0H840A160 160 0 0 1 1000 160V840A160 160 0 0 1 840 1000H160A160 160 0 0 1 0 840V0Z">
+                                </path>
+                            </svg></svg></div>
+                </div>
+                <div class="side-dock-settings"></div>
+            </div>
+            <div class="workspace-split mod-horizontal mod-sidedock mod-left-split" style="width: 325px;">
+                <hr class="workspace-leaf-resize-handle" style="opacity: 1;">
+                <div class="workspace-sidedock-vault-profile">
+                    <div class="workspace-drawer-vault-switcher">
+                        <div class="workspace-drawer-vault-switcher-icon"><svg xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                class="svg-icon lucide-chevrons-up-down">
+                                <path d="m7 15 5 5 5-5"></path>
+                                <path d="m7 9 5-5 5 5"></path>
+                            </svg></div>
+                        <div class="workspace-drawer-vault-name">Obsidian Vault</div>
+                    </div>
+                    <div class="workspace-drawer-vault-actions"><span class="clickable-icon iconic-icon"><svg
+                                xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                stroke-linejoin="round" class="svg-icon help">
+                                <path
+                                    d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z">
+                                </path>
+                                <path
+                                    d="M9.09009 9.00003C9.32519 8.33169 9.78924 7.76813 10.4 7.40916C11.0108 7.05019 12.079 6.94542 12.7773 7.06519C13.9093 7.25935 14.9767 8.25497 14.9748 9.49073C14.9748 11.9908 12 11.2974 12 14">
+                                </path>
+                                <path d="M12 17H12.01"></path>
+                            </svg></span><span class="clickable-icon iconic-icon"><svg
+                                xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                stroke-linejoin="round" class="svg-icon lucide-settings">
+                                <path
+                                    d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915">
+                                </path>
+                                <circle cx="12" cy="12" r="3"></circle>
+                            </svg></span></div>
+                </div>
+                <div class="workspace-sidedock-empty-state" style="display: none;">
+                    <p class="u-muted">The sidebar is empty, try dragging a tab here.</p>
+                </div>
+                <div class="workspace-tabs mod-top mod-top-left-space" style="">
+                    <hr class="workspace-leaf-resize-handle">
+                    <div class="workspace-tab-header-container">
+                        <div class="workspace-tab-header-container-inner" style="--animation-dur: 250ms;">
+                            <div class="workspace-tab-header tappable is-active" draggable="true" aria-label="Files"
+                                data-tooltip-delay="300" data-type="file-explorer">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon lucide-folder-closed">
+                                            <path
+                                                d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z">
+                                            </path>
+                                            <path d="M2 10h20"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Files</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true" aria-label="Search"
+                                data-tooltip-delay="300" data-type="search">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon lucide-search">
+                                            <path d="m21 21-4.34-4.34"></path>
+                                            <circle cx="11" cy="11" r="8"></circle>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Search</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true" aria-label="Bookmarks"
+                                data-tooltip-delay="300" data-type="bookmarks">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon lucide-bookmark">
+                                            <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Bookmarks</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="workspace-tab-header-new-tab"><span class="clickable-icon" aria-label="New tab"><svg
+                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" class="svg-icon lucide-plus">
+                                    <path d="M5 12h14"></path>
+                                    <path d="M12 5v14"></path>
+                                </svg></span></div>
+                        <div class="workspace-tab-header-spacer"></div>
+                        <div class="workspace-tab-header-tab-list"><span class="clickable-icon"><svg
+                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" class="svg-icon lucide-chevron-down">
+                                    <path d="m6 9 6 6 6-6"></path>
+                                </svg></span></div>
+                        <div class="sidebar-toggle-button mod-left" aria-label="" data-tooltip-position="right"
+                            style="">
+                            <div class="clickable-icon iconic-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                    height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                    stroke-linecap="round" stroke-linejoin="round"
+                                    class="svg-icon sidebar-toggle-button-icon">
+                                    <rect x="1" y="2" width="22" height="20" rx="4"></rect>
+                                    <rect x="4" y="5" width="2" height="14" rx="2" fill="currentColor"
+                                        class="sidebar-toggle-icon-inner"></rect>
+                                </svg></div>
+                        </div>
+                    </div>
+                    <div class="workspace-tab-container">
+                        <div class="workspace-leaf">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content" data-type="file-explorer">
+                                <div class="nav-header">
+                                    <div class="nav-buttons-container">
+                                        <div class="clickable-icon nav-action-button" aria-label="New note"><svg
+                                                xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                                stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-edit">
+                                                <path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7">
+                                                </path>
+                                                <path
+                                                    d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z">
+                                                </path>
+                                            </svg></div>
+                                        <div class="clickable-icon nav-action-button" aria-label="New folder"><svg
+                                                xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                                stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-folder-plus">
+                                                <path d="M12 10v6"></path>
+                                                <path d="M9 13h6"></path>
+                                                <path
+                                                    d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z">
+                                                </path>
+                                            </svg></div>
+                                        <div class="clickable-icon nav-action-button" aria-label="Change sort order">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                                stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-sort-asc">
+                                                <path d="m3 8 4-4 4 4"></path>
+                                                <path d="M7 4v16"></path>
+                                                <path d="M11 12h4"></path>
+                                                <path d="M11 16h7"></path>
+                                                <path d="M11 20h10"></path>
+                                            </svg></div>
+                                        <div class="clickable-icon nav-action-button"
+                                            aria-label="Auto-reveal current file"><svg
+                                                xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                                stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-gallery-vertical">
+                                                <path d="M3 2h18"></path>
+                                                <rect x="3" y="6" width="18" height="12" rx="2"></rect>
+                                                <path d="M3 22h18"></path>
+                                            </svg></div>
+                                        <div class="clickable-icon nav-action-button" aria-label="Collapse all"><svg
+                                                xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                                stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-chevrons-down-up">
+                                                <path d="m7 20 5-5 5 5"></path>
+                                                <path d="m7 4 5 5 5-5"></path>
+                                            </svg></div>
+                                    </div>
+                                </div>
+                                <div class="nav-files-container node-insert-event" style="position: relative;">
+                                    <div style="min-height: 2596.6px;">
+                                        <div style="width: 301px; height: 0.1px; margin-bottom: 0px;"></div>
+                                        <div class="tree-item nav-folder is-collapsed iconic-item">
+                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible"
+                                                data-path="DailyNotes" draggable="true"
+                                                style="margin-inline-start: 0px !important; padding-inline-start: 24px !important;">
+                                                <div class="tree-item-icon collapse-icon is-collapsed"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon right-triangle">
+                                                        <path d="M3 8L12 17L21 8"></path>
+                                                    </svg></div>
+                                                <div class="tree-item-inner nav-folder-title-content"
+                                                    data-initialized="true">DailyNotes</div>
+                                            </div>
+                                        </div>
+                                        <div class="tree-item nav-folder iconic-item">
+                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible fn-empty-folder"
+                                                data-path="EvoSiteManager" draggable="true"
+                                                style="margin-inline-start: 0px !important; padding-inline-start: 24px !important;">
+                                                <div class="tree-item-icon collapse-icon"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon right-triangle">
+                                                        <path d="M3 8L12 17L21 8"></path>
+                                                    </svg></div>
+                                                <div class="tree-item-inner nav-folder-title-content"
+                                                    data-initialized="true">EvoSiteManager</div>
+                                            </div>
+                                            <div class="tree-item-children nav-folder-children"
+                                                style="min-height: 0px;"></div>
+                                        </div>
+                                        <div class="tree-item nav-folder is-collapsed iconic-item">
+                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible"
+                                                data-path="MonthlyGoals" draggable="true"
+                                                style="margin-inline-start: 0px !important; padding-inline-start: 24px !important;">
+                                                <div class="tree-item-icon collapse-icon is-collapsed"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon right-triangle">
+                                                        <path d="M3 8L12 17L21 8"></path>
+                                                    </svg></div>
+                                                <div class="tree-item-inner nav-folder-title-content"
+                                                    data-initialized="true">MonthlyGoals</div>
+                                            </div>
+                                        </div>
+                                        <div class="tree-item nav-folder iconic-item">
+                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                data-path="Projects" draggable="true"
+                                                style="margin-inline-start: 0px !important; padding-inline-start: 24px !important;">
+                                                <div class="tree-item-icon collapse-icon"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon right-triangle">
+                                                        <path d="M3 8L12 17L21 8"></path>
+                                                    </svg></div>
+                                                <div class="tree-item-inner nav-folder-title-content"
+                                                    data-initialized="true" old-name="Projects">Projects</div>
+                                            </div>
+                                            <div class="tree-item-children nav-folder-children"
+                                                style="min-height: 1634.78px;">
+                                                <div style="width: 283px; height: 0.1px; margin-bottom: 0px;"></div>
+                                                <div class="tree-item nav-folder is-collapsed iconic-item">
+                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                        data-path="Projects/FitMeal" draggable="true"
+                                                        style="margin-inline-start: -18px !important; padding-inline-start: 42px !important;">
+                                                        <div class="tree-item-icon collapse-icon is-collapsed"><svg
+                                                                xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                height="24" viewBox="0 0 24 24" fill="none"
+                                                                stroke="currentColor" stroke-width="2"
+                                                                stroke-linecap="round" stroke-linejoin="round"
+                                                                class="svg-icon right-triangle">
+                                                                <path d="M3 8L12 17L21 8"></path>
+                                                            </svg></div>
+                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                            data-initialized="true" old-name="FitMeal">FitMeal</div>
+                                                    </div>
+                                                </div>
+                                                <div class="tree-item nav-folder iconic-item">
+                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                        data-path="Projects/Maximus" draggable="true"
+                                                        style="margin-inline-start: -18px !important; padding-inline-start: 42px !important;">
+                                                        <div class="tree-item-icon collapse-icon"><svg
+                                                                xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                height="24" viewBox="0 0 24 24" fill="none"
+                                                                stroke="currentColor" stroke-width="2"
+                                                                stroke-linecap="round" stroke-linejoin="round"
+                                                                class="svg-icon right-triangle">
+                                                                <path d="M3 8L12 17L21 8"></path>
+                                                            </svg></div>
+                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                            data-initialized="true" old-name="Maximus">Maximus</div>
+                                                    </div>
+                                                    <div class="tree-item-children nav-folder-children" style="">
+                                                        <div style="width: 265px; height: 0.1px; margin-bottom: 0px;">
+                                                        </div>
+                                                        <div class="tree-item nav-folder iconic-item">
+                                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                data-path="Projects/Maximus/Integration Enablement"
+                                                                draggable="true"
+                                                                style="margin-inline-start: -36px !important; padding-inline-start: 60px !important;">
+                                                                <div class="tree-item-icon collapse-icon"><svg
+                                                                        xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                        height="24" viewBox="0 0 24 24" fill="none"
+                                                                        stroke="currentColor" stroke-width="2"
+                                                                        stroke-linecap="round" stroke-linejoin="round"
+                                                                        class="svg-icon right-triangle">
+                                                                        <path d="M3 8L12 17L21 8"></path>
+                                                                    </svg></div>
+                                                                <div class="tree-item-inner nav-folder-title-content"
+                                                                    data-initialized="true"
+                                                                    old-name="Integration Enablement">Integration
+                                                                    Enablement</div>
+                                                            </div>
+                                                            <div class="tree-item-children nav-folder-children"
+                                                                style="">
+                                                                <div
+                                                                    style="width: 247px; height: 0.1px; margin-bottom: 0px;">
+                                                                </div>
+                                                                <div
+                                                                    class="tree-item nav-folder is-collapsed iconic-item">
+                                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                        data-path="Projects/Maximus/Integration Enablement/Architecture"
+                                                                        draggable="true"
+                                                                        style="margin-inline-start: -54px !important; padding-inline-start: 78px !important;">
+                                                                        <div
+                                                                            class="tree-item-icon collapse-icon is-collapsed">
+                                                                            <svg xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon right-triangle">
+                                                                                <path d="M3 8L12 17L21 8"></path>
+                                                                            </svg></div>
+                                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                                            data-initialized="true"
+                                                                            old-name="Architecture">Architecture</div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="tree-item nav-folder iconic-item">
+                                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                        data-path="Projects/Maximus/Integration Enablement/Dapr"
+                                                                        draggable="true"
+                                                                        style="margin-inline-start: -54px !important; padding-inline-start: 78px !important;">
+                                                                        <div class="tree-item-icon collapse-icon"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon right-triangle">
+                                                                                <path d="M3 8L12 17L21 8"></path>
+                                                                            </svg></div>
+                                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                                            data-initialized="true" old-name="Dapr">Dapr
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="tree-item-children nav-folder-children"
+                                                                        style="">
+                                                                        <div
+                                                                            style="width: 229px; height: 0.1px; margin-bottom: 0px;">
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Dapr/Dapr.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Dapr</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Dapr/Dapr Reference Repos.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Dapr Reference Repos</div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="tree-item nav-folder iconic-item">
+                                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement"
+                                                                        draggable="true"
+                                                                        style="margin-inline-start: -54px !important; padding-inline-start: 78px !important;">
+                                                                        <div class="tree-item-icon collapse-icon"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon right-triangle">
+                                                                                <path d="M3 8L12 17L21 8"></path>
+                                                                            </svg></div>
+                                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                                            data-initialized="true"
+                                                                            old-name="Engagement">Engagement</div>
+                                                                    </div>
+                                                                    <div class="tree-item-children nav-folder-children"
+                                                                        style="">
+                                                                        <div
+                                                                            style="width: 229px; height: 0.1px; margin-bottom: 0px;">
+                                                                        </div>
+                                                                        <div class="tree-item nav-folder iconic-item">
+                                                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div
+                                                                                    class="tree-item-icon collapse-icon">
+                                                                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                                                                        width="24" height="24"
+                                                                                        viewBox="0 0 24 24" fill="none"
+                                                                                        stroke="currentColor"
+                                                                                        stroke-width="2"
+                                                                                        stroke-linecap="round"
+                                                                                        stroke-linejoin="round"
+                                                                                        class="svg-icon right-triangle">
+                                                                                        <path d="M3 8L12 17L21 8">
+                                                                                        </path>
+                                                                                    </svg></div>
+                                                                                <div class="tree-item-inner nav-folder-title-content"
+                                                                                    data-initialized="true"
+                                                                                    old-name="Anticipated Questions">
+                                                                                    Anticipated Questions</div>
+                                                                            </div>
+                                                                            <div class="tree-item-children nav-folder-children"
+                                                                                style="">
+                                                                                <div
+                                                                                    style="width: 211px; height: 0.1px; margin-bottom: 0px;">
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/Anticipated Questions.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Anticipated Questions</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/API and Integration Surface.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Q&amp;A: API and Integration
+                                                                                            Surface</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/Data Model and Multi-Tenancy.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Q&amp;A: Data Model and
+                                                                                            Multi-Tenancy</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/Infrastructure and Operations.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Q&amp;A: Infrastructure and
+                                                                                            Operations</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/Integration Strategy.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Q&amp;A: Integration
+                                                                                            Strategy</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/Observability.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Q&amp;A: Observability</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/Security.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Q&amp;A: Security</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div
+                                                                                    class="tree-item nav-file iconic-item">
+                                                                                    <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                        data-path="Projects/Maximus/Integration Enablement/Engagement/Anticipated Questions/Team and Process.md"
+                                                                                        draggable="true"
+                                                                                        style="margin-inline-start: -90px !important; padding-inline-start: 114px !important;">
+                                                                                        <div class="tree-item-icon"
+                                                                                            style="display: none;">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="tree-item-inner nav-file-title-content">
+                                                                                            Q&amp;A: Team and Process
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div
+                                                                            class="tree-item nav-folder is-collapsed iconic-item">
+                                                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Engagement/Site Manager Technical Overview"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div
+                                                                                    class="tree-item-icon collapse-icon is-collapsed">
+                                                                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                                                                        width="24" height="24"
+                                                                                        viewBox="0 0 24 24" fill="none"
+                                                                                        stroke="currentColor"
+                                                                                        stroke-width="2"
+                                                                                        stroke-linecap="round"
+                                                                                        stroke-linejoin="round"
+                                                                                        class="svg-icon right-triangle">
+                                                                                        <path d="M3 8L12 17L21 8">
+                                                                                        </path>
+                                                                                    </svg></div>
+                                                                                <div class="tree-item-inner nav-folder-title-content"
+                                                                                    data-initialized="true"
+                                                                                    old-name="Site Manager Technical Overview">
+                                                                                    Site Manager Technical Overview
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div
+                                                                            class="tree-item nav-folder is-collapsed iconic-item">
+                                                                            <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Engagement/Stephen Meeke Q&amp;A - Feb 18"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div
+                                                                                    class="tree-item-icon collapse-icon is-collapsed">
+                                                                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                                                                        width="24" height="24"
+                                                                                        viewBox="0 0 24 24" fill="none"
+                                                                                        stroke="currentColor"
+                                                                                        stroke-width="2"
+                                                                                        stroke-linecap="round"
+                                                                                        stroke-linejoin="round"
+                                                                                        class="svg-icon right-triangle">
+                                                                                        <path d="M3 8L12 17L21 8">
+                                                                                        </path>
+                                                                                    </svg></div>
+                                                                                <div class="tree-item-inner nav-folder-title-content"
+                                                                                    data-initialized="true"
+                                                                                    old-name="Stephen Meeke Q&amp;A - Feb 18">
+                                                                                    Stephen Meeke Q&amp;A - Feb 18</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Engagement/Engagement.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Engagement</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Engagement/QikServe QA Proof of Concept.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    QikServe QA Proof of Concept</div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="tree-item nav-folder iconic-item">
+                                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                        data-path="Projects/Maximus/Integration Enablement/Stakeholders"
+                                                                        draggable="true"
+                                                                        style="margin-inline-start: -54px !important; padding-inline-start: 78px !important;">
+                                                                        <div class="tree-item-icon collapse-icon"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon right-triangle">
+                                                                                <path d="M3 8L12 17L21 8"></path>
+                                                                            </svg></div>
+                                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                                            data-initialized="true"
+                                                                            old-name="Stakeholders">Stakeholders</div>
+                                                                    </div>
+                                                                    <div class="tree-item-children nav-folder-children"
+                                                                        style="">
+                                                                        <div
+                                                                            style="width: 229px; height: 0.1px; margin-bottom: 0px;">
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Stakeholders/Andrew Douglas.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Andrew Douglas</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Stakeholders/David Wooderson.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    David Wooderson</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Stakeholders/Platform Team.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Platform Team</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Stakeholders/Stakeholders.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Stakeholders</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Stakeholders/Stephen Meeke.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Stephen Meeke</div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="tree-item nav-folder iconic-item">
+                                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                                        data-path="Projects/Maximus/Integration Enablement/Status"
+                                                                        draggable="true"
+                                                                        style="margin-inline-start: -54px !important; padding-inline-start: 78px !important;">
+                                                                        <div class="tree-item-icon collapse-icon"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon right-triangle">
+                                                                                <path d="M3 8L12 17L21 8"></path>
+                                                                            </svg></div>
+                                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                                            data-initialized="true" old-name="Status">
+                                                                            Status</div>
+                                                                    </div>
+                                                                    <div class="tree-item-children nav-folder-children"
+                                                                        style="">
+                                                                        <div
+                                                                            style="width: 229px; height: 0.1px; margin-bottom: 0px;">
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Status/Current State.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Current State</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Status/Next Steps.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Next Steps</div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="tree-item nav-file iconic-item">
+                                                                            <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                                data-path="Projects/Maximus/Integration Enablement/Status/Status.md"
+                                                                                draggable="true"
+                                                                                style="margin-inline-start: -72px !important; padding-inline-start: 96px !important;">
+                                                                                <div class="tree-item-icon"
+                                                                                    style="display: none;"></div>
+                                                                                <div
+                                                                                    class="tree-item-inner nav-file-title-content">
+                                                                                    Status</div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="tree-item nav-file iconic-item">
+                                                                    <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                        data-path="Projects/Maximus/Integration Enablement/Integration Enablement.md"
+                                                                        draggable="true"
+                                                                        style="margin-inline-start: -54px !important; padding-inline-start: 78px !important;">
+                                                                        <div class="tree-item-icon"
+                                                                            style="display: none;"></div>
+                                                                        <div
+                                                                            class="tree-item-inner nav-file-title-content">
+                                                                            Integration Enablement</div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="tree-item nav-file iconic-item">
+                                                            <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                data-path="Projects/Maximus/Maximus.md" draggable="true"
+                                                                style="margin-inline-start: -36px !important; padding-inline-start: 60px !important;">
+                                                                <div class="tree-item-icon" style="display: none;">
+                                                                </div>
+                                                                <div class="tree-item-inner nav-file-title-content">
+                                                                    Maximus</div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="tree-item nav-folder iconic-item">
+                                                    <div class="tree-item-self nav-folder-title is-clickable mod-collapsible has-folder-note"
+                                                        data-path="Projects/ObsidianProductivity" draggable="true"
+                                                        style="margin-inline-start: -18px !important; padding-inline-start: 42px !important;">
+                                                        <div class="tree-item-icon collapse-icon"><svg
+                                                                xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                height="24" viewBox="0 0 24 24" fill="none"
+                                                                stroke="currentColor" stroke-width="2"
+                                                                stroke-linecap="round" stroke-linejoin="round"
+                                                                class="svg-icon right-triangle">
+                                                                <path d="M3 8L12 17L21 8"></path>
+                                                            </svg></div>
+                                                        <div class="tree-item-inner nav-folder-title-content"
+                                                            data-initialized="true" old-name="ObsidianProductivity">
+                                                            ObsidianProductivity</div>
+                                                    </div>
+                                                    <div class="tree-item-children nav-folder-children"
+                                                        style="min-height: 76.8438px;">
+                                                        <div style="width: 265px; height: 0.1px; margin-bottom: 0px;">
+                                                        </div>
+                                                        <div class="tree-item nav-file iconic-item">
+                                                            <div class="tree-item-self nav-file-title tappable is-clickable"
+                                                                data-path="Projects/ObsidianProductivity/mtn Fork Wishlist.md"
+                                                                draggable="true"
+                                                                style="margin-inline-start: -36px !important; padding-inline-start: 60px !important;">
+                                                                <div class="tree-item-icon" style="display: none;">
+                                                                </div>
+                                                                <div class="tree-item-inner nav-file-title-content">mtn
+                                                                    Fork Wishlist</div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="tree-item nav-file iconic-item">
+                                                            <div class="tree-item-self nav-file-title tappable is-clickable is-folder-note"
+                                                                data-path="Projects/ObsidianProductivity/ObsidianProductivity.md"
+                                                                draggable="true"
+                                                                style="margin-inline-start: -36px !important; padding-inline-start: 60px !important;">
+                                                                <div class="tree-item-icon" style="display: none;">
+                                                                </div>
+                                                                <div class="tree-item-inner nav-file-title-content">
+                                                                    ObsidianProductivity</div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="workspace-split mod-vertical mod-root">
+                <hr class="workspace-leaf-resize-handle">
+                <div class="workspace-tabs mod-active mod-top">
+                    <hr class="workspace-leaf-resize-handle">
+                    <div class="workspace-tab-header-container">
+                        <div class="workspace-tab-header-container-inner" style="--animation-dur: 250ms;">
+                            <div class="workspace-tab-header tappable is-active mod-active" draggable="true"
+                                aria-label="Fix mtn NLP to use prefix-based parsing instead of bare word matching"
+                                data-tooltip-delay="300" data-type="markdown">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon" style="display: none;"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-file">
+                                            <path
+                                                d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z">
+                                            </path>
+                                            <path d="M14 2v5a1 1 0 0 0 1 1h5"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Fix mtn NLP to use prefix-based
+                                        parsing instead of bare word matching</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="workspace-tab-header-new-tab"><span class="clickable-icon" aria-label="New tab"><svg
+                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" class="svg-icon lucide-plus">
+                                    <path d="M5 12h14"></path>
+                                    <path d="M12 5v14"></path>
+                                </svg></span></div>
+                        <div class="workspace-tab-header-spacer"></div>
+                        <div class="workspace-tab-header-tab-list"><span class="clickable-icon"><svg
+                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" class="svg-icon lucide-chevron-down">
+                                    <path d="m6 9 6 6 6-6"></path>
+                                </svg></span></div>
+                    </div>
+                    <div class="workspace-tab-container">
+                        <div class="workspace-leaf mod-active">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content" data-type="markdown" data-mode="source">
+                                <div class="view-header">
+                                    <div class="view-header-left">
+                                        <div class="view-header-nav-buttons"><button class="clickable-icon"
+                                                aria-disabled="true" aria-label="Navigate back"><svg
+                                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                    viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                    stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                    class="svg-icon lucide-arrow-left">
+                                                    <path d="m12 19-7-7 7-7"></path>
+                                                    <path d="M19 12H5"></path>
+                                                </svg></button><button class="clickable-icon" aria-disabled="true"
+                                                aria-label="Navigate forward"><svg xmlns="http://www.w3.org/2000/svg"
+                                                    width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                                    stroke-linejoin="round" class="svg-icon lucide-arrow-right">
+                                                    <path d="M5 12h14"></path>
+                                                    <path d="m12 5 7 7-7 7"></path>
+                                                </svg></button></div>
+                                    </div>
+                                    <div class="view-header-title-container mod-at-start mod-fade mod-at-end">
+                                        <div class="view-header-title-parent"><span class="view-header-breadcrumb"
+                                                aria-label="TaskNotes" draggable="true">TaskNotes</span><span
+                                                class="view-header-breadcrumb-separator">/</span><span
+                                                class="view-header-breadcrumb" aria-label="Tasks"
+                                                draggable="true">Tasks</span><span
+                                                class="view-header-breadcrumb-separator">/</span></div>
+                                        <div class="view-header-title" tabindex="-1" contenteditable="true" hidden="">
+                                            Fix mtn NLP to use prefix-based parsing instead of bare word matching</div>
+                                        <div class="view-header-title" data-ofmt="true">Fix mtn NLP to use prefix-based
+                                            parsing instead of bare word matching</div>
+                                    </div>
+                                    <div class="view-actions"><button class="clickable-icon view-action mod-bookmark"
+                                            aria-label="Bookmark"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-bookmark">
+                                                <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"></path>
+                                            </svg></button><button class="clickable-icon view-action" aria-label="Current view: editing
+Click to read
+⌘+Click to open to the right"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                                fill="none" stroke="currentColor" stroke-width="2"
+                                                stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-book-open">
+                                                <path d="M12 7v14"></path>
+                                                <path
+                                                    d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z">
+                                                </path>
+                                            </svg></button><button class="clickable-icon view-action"
+                                            aria-label="More options"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-more-vertical">
+                                                <circle cx="12" cy="12" r="1"></circle>
+                                                <circle cx="12" cy="5" r="1"></circle>
+                                                <circle cx="12" cy="19" r="1"></circle>
+                                            </svg></button></div>
+                                </div>
+                                <div class="view-content">
+                                    <div class="markdown-source-view cm-s-obsidian mod-cm6 node-insert-event is-readable-line-width is-live-preview is-folding show-properties"
+                                        style="">
+                                        <div class="cm-editor ͼ1 ͼ2 ">
+                                            <div class="cm-announced" aria-live="polite"></div>
+                                            <div tabindex="-1" class="cm-scroller">
+                                                <div class="cm-sizer">
+                                                    <div class="iconic-title-wrapper">
+                                                        <div class="iconic-icon" style="display: none;"></div>
+                                                        <div class="inline-title"
+                                                            ofmt-fake-id="source-inlineTitle-8e2e2abff266e9be"
+                                                            tabindex="-1">Fix mtn NLP to use prefix-based parsing
+                                                            instead of bare word matching</div>
+                                                        <div class="inline-title" contenteditable="true"
+                                                            spellcheck="true" autocapitalize="on" tabindex="-1"
+                                                            enterkeyhint="done"
+                                                            ofmt-original-id="source-inlineTitle-8e2e2abff266e9be"
+                                                            hidden="">Fix mtn NLP to use prefix-based parsing instead of
+                                                            bare word matching</div>
+                                                    </div>
+                                                    <div class="metadata-container" tabindex="-1"
+                                                        data-property-count="9">
+                                                        <div class="metadata-error-container" style="display: none;">
+                                                        </div>
+                                                        <div class="metadata-properties-heading" tabindex="0">
+                                                            <div class="collapse-indicator collapse-icon"><svg
+                                                                    xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                    height="24" viewBox="0 0 24 24" fill="none"
+                                                                    stroke="currentColor" stroke-width="2"
+                                                                    stroke-linecap="round" stroke-linejoin="round"
+                                                                    class="svg-icon right-triangle">
+                                                                    <path d="M3 8L12 17L21 8"></path>
+                                                                </svg></div>
+                                                            <div class="metadata-properties-title">Properties</div>
+                                                        </div>
+                                                        <div class="metadata-content">
+                                                            <div class="metadata-properties">
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="title">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="title"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">Fix mtn NLP
+                                                                            to use prefix-based parsing instead of bare
+                                                                            word matching</div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="tags">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-tags">
+                                                                                <path
+                                                                                    d="M13.172 2a2 2 0 0 1 1.414.586l6.71 6.71a2.4 2.4 0 0 1 0 3.408l-4.592 4.592a2.4 2.4 0 0 1-3.408 0l-6.71-6.71A2 2 0 0 1 6 9.172V3a1 1 0 0 1 1-1z">
+                                                                                </path>
+                                                                                <path
+                                                                                    d="M2 7v6.172a2 2 0 0 0 .586 1.414l6.71 6.71a2.4 2.4 0 0 0 3.191.193">
+                                                                                </path>
+                                                                                <circle cx="10.5" cy="6.5" r="0.5">
+                                                                                </circle>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="tags"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="tags">
+                                                                        <div class="multi-select-container"
+                                                                            tabindex="-1">
+                                                                            <div class="multi-select-pill" tabindex="0">
+                                                                                <div class="multi-select-pill-content">
+                                                                                    <span>personal</span></div>
+                                                                                <div
+                                                                                    class="multi-select-pill-remove-button">
+                                                                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                                                                        width="24" height="24"
+                                                                                        viewBox="0 0 24 24" fill="none"
+                                                                                        stroke="currentColor"
+                                                                                        stroke-width="2"
+                                                                                        stroke-linecap="round"
+                                                                                        stroke-linejoin="round"
+                                                                                        class="svg-icon lucide-x">
+                                                                                        <path d="M18 6 6 18"></path>
+                                                                                        <path d="m6 6 12 12"></path>
+                                                                                    </svg></div>
+                                                                            </div>
+                                                                            <div class="multi-select-pill" tabindex="0">
+                                                                                <div class="multi-select-pill-content">
+                                                                                    <span>task</span></div>
+                                                                                <div
+                                                                                    class="multi-select-pill-remove-button">
+                                                                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                                                                        width="24" height="24"
+                                                                                        viewBox="0 0 24 24" fill="none"
+                                                                                        stroke="currentColor"
+                                                                                        stroke-width="2"
+                                                                                        stroke-linecap="round"
+                                                                                        stroke-linejoin="round"
+                                                                                        class="svg-icon lucide-x">
+                                                                                        <path d="M18 6 6 18"></path>
+                                                                                        <path d="m6 6 12 12"></path>
+                                                                                    </svg></div>
+                                                                            </div>
+                                                                            <div class="multi-select-input"
+                                                                                contenteditable="true" tabindex="0"
+                                                                                placeholder="" autocapitalize="none">
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Tags"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="datecreated">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="dateCreated"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">
+                                                                            2026-02-16T15:08:08.784-03:00</div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="datemodified">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="dateModified"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">
+                                                                            2026-02-16T15:08:08.784-03:00</div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="type">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="type"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">task</div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="status">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="status"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">open</div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="priority">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="priority"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">high</div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="recurrence_anchor">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="recurrence_anchor">
+                                                                    </div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">scheduled
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                                <div class="metadata-property" tabindex="0"
+                                                                    data-property-key="project">
+                                                                    <div class="metadata-property-key"><span
+                                                                            class="metadata-property-icon iconic-icon"
+                                                                            aria-disabled="false"><svg
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                width="24" height="24"
+                                                                                viewBox="0 0 24 24" fill="none"
+                                                                                stroke="currentColor" stroke-width="2"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                class="svg-icon lucide-text">
+                                                                                <path d="M21 5H3"></path>
+                                                                                <path d="M15 12H3"></path>
+                                                                                <path d="M17 19H3"></path>
+                                                                            </svg></span><input
+                                                                            class="metadata-property-key-input"
+                                                                            autocapitalize="none" enterkeyhint="next"
+                                                                            type="text" aria-label="project"></div>
+                                                                    <div class="metadata-property-value"
+                                                                        data-property-type="text">
+                                                                        <div class="metadata-input-longtext"
+                                                                            placeholder="Empty" contenteditable="true"
+                                                                            spellcheck="true" tabindex="0">mtn Fork
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="clickable-icon metadata-property-warning-icon"
+                                                                        aria-label="Type mismatch, expected Text"
+                                                                        style="display: none;"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon lucide-alert-triangle">
+                                                                            <path
+                                                                                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3">
+                                                                            </path>
+                                                                            <path d="M12 9v4"></path>
+                                                                            <path d="M12 17h.01"></path>
+                                                                        </svg></div>
+                                                                </div>
+                                                            </div>
+                                                            <div class="metadata-add-button text-icon-button"
+                                                                tabindex="0"><span class="text-button-icon"><svg
+                                                                        xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                        height="24" viewBox="0 0 24 24" fill="none"
+                                                                        stroke="currentColor" stroke-width="2"
+                                                                        stroke-linecap="round" stroke-linejoin="round"
+                                                                        class="svg-icon lucide-plus">
+                                                                        <path d="M5 12h14"></path>
+                                                                        <path d="M12 5v14"></path>
+                                                                    </svg></span><span class="text-button-label">Add
+                                                                    property</span></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="tasknotes-plugin task-card-note-widget tasknotes-task-card-note-widget"
+                                                        contenteditable="false" spellcheck="false"
+                                                        data-widget-type="task-card">
+                                                        <div class="task-card task-card--priority-high task-card--status-open task-card-note-widget__card"
+                                                            data-task-path="TaskNotes/Tasks/Fix mtn NLP to use prefix-based parsing instead of bare word matching.md"
+                                                            data-key="TaskNotes/Tasks/Fix mtn NLP to use prefix-based parsing instead of bare word matching.md"
+                                                            data-status="open"
+                                                            style="--priority-color: #ff0000; --current-status-color: #808080; --next-status-color: #0066cc;">
+                                                            <div class="task-card__main-row"><span
+                                                                    class="task-card__status-dot"
+                                                                    style="border-color: rgb(128, 128, 128);"></span><span
+                                                                    class="task-card__priority-dot"
+                                                                    aria-label="Priority: High"
+                                                                    style="border-color: rgb(255, 0, 0);"></span>
+                                                                <div class="task-card__content">
+                                                                    <div class="task-card__title"><span
+                                                                            class="task-card__title-text">Fix mtn NLP to
+                                                                            use prefix-based parsing instead of bare
+                                                                            word matching</span></div>
+                                                                    <div class="task-card__metadata"><span
+                                                                            class="task-card__metadata-property task-card__metadata-property--tags"><a
+                                                                                class="tag" href="#personal"
+                                                                                role="button" tabindex="0">#personal</a>
+                                                                            <a class="tag" href="#task" role="button"
+                                                                                tabindex="0">#task</a></span></div>
+                                                                </div>
+                                                                <div class="task-card__badges"></div>
+                                                                <div class="task-card__context-menu"
+                                                                    aria-label="Task options"
+                                                                    data-tooltip-position="top"><svg
+                                                                        xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                        height="24" viewBox="0 0 24 24" fill="none"
+                                                                        stroke="currentColor" stroke-width="2"
+                                                                        stroke-linecap="round" stroke-linejoin="round"
+                                                                        class="svg-icon lucide-ellipsis-vertical">
+                                                                        <circle cx="12" cy="12" r="1"></circle>
+                                                                        <circle cx="12" cy="5" r="1"></circle>
+                                                                        <circle cx="12" cy="19" r="1"></circle>
+                                                                    </svg></div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="cm-contentContainer">
+                                                        <div class="cm-gutters cm-gutters-before" aria-hidden="true"
+                                                            style="min-height: 3434.4px; position: sticky;">
+                                                            <div class="cm-gutter heading-decorator-gutter">
+                                                                <div class="cm-gutterElement"
+                                                                    style="height: 64.5px; padding-top: 16px; line-height: 48px;">
+                                                                    <div class="heading-decorator-gutter-marker"
+                                                                        data-decorator-opacity="80%"
+                                                                        data-decorator-level="1">1</div>
+                                                                </div>
+                                                                <div class="cm-gutterElement"
+                                                                    style="height: 64.5px; margin-top: 169px; padding-top: 16px; line-height: 48px;">
+                                                                    <div class="heading-decorator-gutter-marker"
+                                                                        data-decorator-opacity="80%"
+                                                                        data-decorator-level="1">2</div>
+                                                                </div>
+                                                                <div class="cm-gutterElement"
+                                                                    style="height: 64.5px; margin-top: 466.5px; padding-top: 16px; line-height: 48px;">
+                                                                    <div class="heading-decorator-gutter-marker"
+                                                                        data-decorator-opacity="80%"
+                                                                        data-decorator-level="1">3</div>
+                                                                </div>
+                                                                <div class="cm-gutterElement"
+                                                                    style="height: 39.8984px; margin-top: 24px; padding-top: 0px; line-height: 38.4px;">
+                                                                    <div class="heading-decorator-gutter-marker"
+                                                                        data-decorator-opacity="80%"
+                                                                        data-decorator-level="2">3.1</div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div spellcheck="true" autocorrect="on" autocapitalize="on"
+                                                            writingsuggestions="false" translate="no"
+                                                            contenteditable="true"
+                                                            style="tab-size: 4; padding-bottom: 498px;"
+                                                            class="cm-content cm-lineWrapping" role="textbox"
+                                                            aria-multiline="true" data-language="templater">
+                                                            <div contenteditable="false"></div>
+                                                            <div class="cm-active HyperMD-header HyperMD-header-1 cm-line"
+                                                                dir="ltr">
+                                                                <div class="cm-fold-indicator" contenteditable="false">
+                                                                    <div class="collapse-indicator collapse-icon"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon right-triangle">
+                                                                            <path d="M3 8L12 17L21 8"></path>
+                                                                        </svg></div>
+                                                                </div><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-1">Problem</span>
+                                                            </div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="cm-line" dir="ltr">The NLP parser in <img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">tasknotes-nlp-core@0.1.0</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> uses
+                                                                bare regex (<img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">\b(high|important)\b</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true">) to
+                                                                match priority and status from titles. This silently
+                                                                mangles natural language:</div>
+                                                            <div class="HyperMD-list-line HyperMD-list-line-1 cm-line"
+                                                                dir="ltr"
+                                                                style="text-indent: -22px; padding-inline-start: 22px;">
+                                                                <span
+                                                                    class="cm-formatting cm-formatting-list cm-formatting-list-ul cm-list-1"><span
+                                                                        class="list-bullet">-</span> </span><span
+                                                                    class="cm-list-1">"High performance system" -&gt;
+                                                                    "performance system" with high priority</span></div>
+                                                            <div class="HyperMD-list-line HyperMD-list-line-1 cm-line"
+                                                                dir="ltr"
+                                                                style="text-indent: -22px; padding-inline-start: 22px;">
+                                                                <span
+                                                                    class="cm-formatting cm-formatting-list cm-formatting-list-ul cm-list-1"><span
+                                                                        class="list-bullet">-</span> </span><span
+                                                                    class="cm-list-1">"Open source contribution" -&gt;
+                                                                    "source contribution" with open status</span></div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="HyperMD-header HyperMD-header-1 cm-line"
+                                                                dir="ltr">
+                                                                <div class="cm-fold-indicator" contenteditable="false">
+                                                                    <div class="collapse-indicator collapse-icon"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon right-triangle">
+                                                                            <path d="M3 8L12 17L21 8"></path>
+                                                                        </svg></div>
+                                                                </div><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-1">Key Discovery</span>
+                                                            </div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="cm-line" dir="ltr"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-strong">The prefix/trigger system already
+                                                                    exists in </span><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code cm-strong"
+                                                                    spellcheck="false">tasknotes-nlp-core</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-strong">.</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> The <img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">TriggerConfigService</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> and <img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">DEFAULT_NLP_TRIGGERS</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> define:
+                                                            </div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-begin HyperMD-codeblock-begin-bg HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="code-block-flair" aria-label="Copy"
+                                                                    contenteditable="false">JavaScript</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-comment cm-hmd-codeblock"
+                                                                    spellcheck="false">// defaults.js</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr">
+                                                                <div class="cm-fold-indicator" contenteditable="false">
+                                                                    <div class="collapse-indicator collapse-icon"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon right-triangle">
+                                                                            <path d="M3 8L12 17L21 8"></path>
+                                                                        </svg></div>
+                                                                </div><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    class="cm-hmd-codeblock cm-keyword"
+                                                                    spellcheck="false">export</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                </span><span class="cm-hmd-codeblock cm-keyword"
+                                                                    spellcheck="false">const</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                </span><span class="cm-def cm-hmd-codeblock"
+                                                                    spellcheck="false">DEFAULT_NLP_TRIGGERS</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                </span><span class="cm-hmd-codeblock cm-operator"
+                                                                    spellcheck="false">=</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                    {</span>
+                                                            </div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false"><span class="cm-indent-spacing">
+                                                                    </span></span>
+                                                                <div class="cm-fold-indicator" contenteditable="false">
+                                                                    <div class="collapse-indicator collapse-icon"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon right-triangle">
+                                                                            <path d="M3 8L12 17L21 8"></path>
+                                                                        </svg></div>
+                                                                </div><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">triggers</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                    [</span>
+                                                            </div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false"><span class="cm-indent"> </span>{
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">propertyId</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"tags"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">trigger</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"#"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">enabled</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-atom cm-hmd-codeblock"
+                                                                    spellcheck="false">true</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                    },</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false"><span class="cm-indent"> </span>{
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">propertyId</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"contexts"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">trigger</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"@"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">enabled</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-atom cm-hmd-codeblock"
+                                                                    spellcheck="false">true</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                    },</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false"><span class="cm-indent"> </span>{
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">propertyId</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"projects"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">trigger</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"+"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">enabled</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-atom cm-hmd-codeblock"
+                                                                    spellcheck="false">true</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                    },</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false"><span class="cm-indent"> </span>{
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">propertyId</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"status"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">trigger</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"*"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">enabled</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-atom cm-hmd-codeblock"
+                                                                    spellcheck="false">true</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                    },</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false"><span class="cm-indent"> </span>{
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">propertyId</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"priority"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">trigger</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"!"</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-property"
+                                                                    spellcheck="false">enabled</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">:
+                                                                </span><span class="cm-atom cm-hmd-codeblock"
+                                                                    spellcheck="false">false</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false"> },
+                                                                </span><span class="cm-comment cm-hmd-codeblock"
+                                                                    spellcheck="false">// &lt;-- DISABLED</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false"><span class="cm-indent-spacing">
+                                                                    </span>],</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock"
+                                                                    spellcheck="false">};</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg HyperMD-codeblock-end HyperMD-codeblock-end-bg cm-line"
+                                                                dir="ltr"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"></div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="cm-line" dir="ltr">The problem: <img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">!</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> priority
+                                                                trigger is <img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-strong">disabled</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true">, so <img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">extractPriority()</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> falls
+                                                                through to bare-word regex matching.</div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="HyperMD-header HyperMD-header-1 cm-line"
+                                                                dir="ltr">
+                                                                <div class="cm-fold-indicator" contenteditable="false">
+                                                                    <div class="collapse-indicator collapse-icon"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon right-triangle">
+                                                                            <path d="M3 8L12 17L21 8"></path>
+                                                                        </svg></div>
+                                                                </div><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-1">Fix Scope (3 Changes
+                                                                    in Our fork)</span>
+                                                            </div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="HyperMD-header HyperMD-header-2 cm-line"
+                                                                dir="ltr">
+                                                                <div class="cm-fold-indicator" contenteditable="false">
+                                                                    <div class="collapse-indicator collapse-icon"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon right-triangle">
+                                                                            <path d="M3 8L12 17L21 8"></path>
+                                                                        </svg></div>
+                                                                </div><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-2">1. Enable </span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-2 cm-inline-code"
+                                                                    spellcheck="false">!</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-2"> Priority Trigger
+                                                                    (</span><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-2 cm-inline-code"
+                                                                    spellcheck="false">src/nlp.ts</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-header cm-header-2"> Line 62)</span>
+                                                            </div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="cm-line" dir="ltr">Pass <img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">nlpTriggers</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> with
+                                                                <img class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="cm-inline-code"
+                                                                    spellcheck="false">!</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"> priority
+                                                                enabled to the parser constructor:</div>
+                                                            <div class="cm-line" dir="ltr"><br></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-begin HyperMD-codeblock-begin-bg HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    contenteditable="false"></span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"><span
+                                                                    class="code-block-flair" aria-label="Copy"
+                                                                    contenteditable="false">TypeScript</span><img
+                                                                    class="cm-widgetBuffer" aria-hidden="true"></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-comment cm-hmd-codeblock"
+                                                                    spellcheck="false">// BEFORE</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-hmd-codeblock cm-keyword"
+                                                                    spellcheck="false">return</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                </span><span class="cm-hmd-codeblock cm-keyword"
+                                                                    spellcheck="false">new</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                </span><span class="cm-hmd-codeblock cm-variable"
+                                                                    spellcheck="false">NaturalLanguageParserCore</span><span
+                                                                    class="cm-hmd-codeblock"
+                                                                    spellcheck="false">(</span><span
+                                                                    class="cm-hmd-codeblock cm-variable"
+                                                                    spellcheck="false">statusConfigs</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-variable"
+                                                                    spellcheck="false">priorityConfigs</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-atom cm-hmd-codeblock"
+                                                                    spellcheck="false">true</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">,
+                                                                </span><span class="cm-hmd-codeblock cm-string"
+                                                                    spellcheck="false">"en"</span><span
+                                                                    class="cm-hmd-codeblock"
+                                                                    spellcheck="false">);</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><br></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr"><span class="cm-comment cm-hmd-codeblock"
+                                                                    spellcheck="false">// AFTER</span></div>
+                                                            <div class="HyperMD-codeblock HyperMD-codeblock-bg cm-line"
+                                                                dir="ltr">
+                                                                <div class="cm-fold-indicator" contenteditable="false">
+                                                                    <div class="collapse-indicator collapse-icon"><svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            width="24" height="24" viewBox="0 0 24 24"
+                                                                            fill="none" stroke="currentColor"
+                                                                            stroke-width="2" stroke-linecap="round"
+                                                                            stroke-linejoin="round"
+                                                                            class="svg-icon right-triangle">
+                                                                            <path d="M3 8L12 17L21 8"></path>
+                                                                        </svg></div>
+                                                                </div><img class="cm-widgetBuffer"
+                                                                    aria-hidden="true"><span
+                                                                    class="cm-hmd-codeblock cm-keyword"
+                                                                    spellcheck="false">const</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                </span><span class="cm-def cm-hmd-codeblock"
+                                                                    spellcheck="false">nlpTriggers</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                </span><span class="cm-hmd-codeblock cm-operator"
+                                                                    spellcheck="false">=</span><span
+                                                                    class="cm-hmd-codeblock" spellcheck="false">
+                                                                    {</span>
+                                                            </div>
+                                                            <div class="cm-gap" style="height: 1824px;"></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="tasknotes-plugin tasknotes-relationships-widget"
+                                                        contenteditable="false" spellcheck="false"
+                                                        data-widget-type="relationships">
+                                                        <div class="relationships__bases-container">
+                                                            <p dir="auto"><span alt="TaskNotes/Views/relationships.base"
+                                                                    src="TaskNotes/Views/relationships.base"
+                                                                    class="internal-embed bases-embed interactive-child is-loaded tasknotes-view-active">
+                                                                    <div class="bases-header">
+                                                                        <div class="bases-toolbar">
+                                                                            <div
+                                                                                class="bases-toolbar-item bases-toolbar-views-menu">
+                                                                                <div class="text-icon-button"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            viewBox="0 0 100 100"
+                                                                                            class="svg-icon tasknotes-simple">
+                                                                                            <g>
+                                                                                                <defs>
+                                                                                                    <mask
+                                                                                                        id="tasknotes-mask">
+                                                                                                        <rect
+                                                                                                            width="100"
+                                                                                                            height="100"
+                                                                                                            fill="white">
+                                                                                                        </rect>
+                                                                                                        <path
+                                                                                                            fill="black"
+                                                                                                            d="m 5.9,52.4 -0.09,4.51 c 4.71,0.09 7.61,1.48 9.95,3.57 2.35,2.09 4.11,5.01 5.90,8.14 1.80,3.13 3.62,6.46 6.45,9.12 2.23,2.09 5.14,3.67 8.83,4.21 0.46,-1.51 1.05,-2.95 1.77,-4.33 -3.44,-0.21 -5.62,-1.39 -7.53,-3.17 -2.14,-2.01 -3.82,-4.92 -5.63,-8.08 -1.81,-3.16 -3.77,-6.56 -6.82,-9.27 -3.05,-2.71 -7.07,-4.59 -11.83,-4.70 z">
+                                                                                                        </path>
+                                                                                                        <path
+                                                                                                            fill="black"
+                                                                                                            d="M 73.6,18.3 69.9,20.9 c 4.06,5.75 4.40,11.33 2.77,16.78 -1.63,5.45 -5.41,10.67 -9.65,14.78 -8.49,8.20 -16.59,14.11 -21.83,21.18 -5.24,7.07 -7.22,15.59 -3.13,27.21 l 4.25,-1.50 c -3.74,-10.62 -2.11,-16.80 2.50,-23.01 4.61,-6.21 12.63,-12.19 21.34,-20.64 4.65,-4.50 8.89,-10.23 10.84,-16.72 1.95,-6.49 1.42,-13.86 -3.40,-20.68 z">
+                                                                                                        </path>
+                                                                                                    </mask>
+                                                                                                </defs>
+                                                                                                <path
+                                                                                                    fill="currentColor"
+                                                                                                    mask="url(#tasknotes-mask)"
+                                                                                                    d="m 98.5,0.6 c -0.38,0 -0.83,0.09 -1.33,0.23 -2,0.59 -4.66,2.18 -5.78,3.22 -1.25,1.16 -4.16,4.93 -6.08,7.19 -2.67,3.12 -5.65,6.58 -9.32,11.13 2.58,5.61 2.61,11.38 1.05,16.60 -1.95,6.49 -6.19,12.22 -10.84,16.72 -8.71,8.43 -16.73,14.41 -21.34,20.64 -4.47,6.03 -6.13,12.03 -2.81,22.08 0.19,-0.23 0.37,-0.49 0.54,-0.80 10.57,-19.70 17.89,-27.30 41.9,-47.08 v 0 c 2.40,-1.97 3.71,-4.33 4.52,-7.14 0.81,-2.82 1.11,-6.10 1.52,-9.92 0.81,-7.64 2.02,-17.43 8.43,-29.95 0.37,-0.73 0.57,-1.30 0.62,-1.72 0.05,-0.43 -0.04,-0.71 -0.22,-0.90 -0.19,-0.18 -0.48,-0.27 -0.86,-0.26 z M 72.7,26.3 c -0.75,0.92 -1.51,1.84 -2.27,2.78 -9.09,11.05 -19.45,22.93 -28.54,29.97 -1.48,1.14 -2.98,1.54 -4.46,1.38 -1.49,-0.16 -2.97,-0.89 -4.43,-1.96 -2.91,-2.16 -5.74,-5.74 -8.35,-9.19 -2.62,-3.45 -5.04,-6.77 -7.12,-8.39 -1.04,-0.81 -1.99,-1.19 -2.83,-0.97 -0.84,0.22 -1.60,1.05 -2.26,2.70 -1.03,2.61 -1.60,6.22 -3.42,10.05 4.08,0.62 7.27,2.27 9.73,4.45 3.05,2.71 5.01,6.11 6.82,9.27 1.81,3.16 3.49,6.07 5.63,8.08 1.90,1.78 4.08,2.96 7.53,3.17 0.71,-1.37 1.55,-2.69 2.49,-3.95 5.24,-7.07 13.34,-12.98 21.83,-21.18 4.24,-4.11 8.02,-9.33 9.65,-14.78 1.12,-3.73 1.31,-7.53 0.01,-11.42 z M 10.3,49.1 c -0.09,0.29 -0.18,0.56 -0.28,0.85 0.10,-0.29 0.19,-0.56 0.28,-0.85 z m -4.02,7.84 c -0.01,0.01 -0.02,0.02 -0.03,0.03 0.01,-0.01 0.02,-0.02 0.03,-0.03 0,0 0,0 0,0 z m 0.12,0 c -1.08,1.40 -2.40,2.79 -4.05,4.12 -1.20,1.0 -1.85,1.86 -2.03,2.71 -0.18,0.85 0.10,1.67 0.76,2.53 1.32,1.71 4.16,3.54 7.81,5.91 7.28,4.73 17.75,11.63 25.63,24.16 0.64,1.02 1.74,2.04 2.95,2.65 -0.91,-5.36 -0.91,-8.78 -0.54,-11.88 -3.33,-0.55 -6.07,-2.12 -8.39,-4.72 -2.83,-3.17 -4.69,-6.59 -6.54,-9.85 -1.85,-3.26 -3.69,-6.37 -6.08,-8.47 -2.06,-1.81 -4.61,-3.0 -8.49,-3.17 z">
+                                                                                                </path>
+                                                                                            </g>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">Subtasks</span><span
+                                                                                        class="text-button-icon mod-aux"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-chevrons-up-down">
+                                                                                            <path d="m7 15 5 5 5-5">
+                                                                                            </path>
+                                                                                            <path d="m7 9 5-5 5 5">
+                                                                                            </path>
+                                                                                        </svg></span></div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="bases-toolbar-item bases-toolbar-results-menu bases-toolbar-result-count">
+                                                                                <div class="text-icon-button"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-list-filter">
+                                                                                            <path d="M2 5h20"></path>
+                                                                                            <path d="M6 12h12"></path>
+                                                                                            <path d="M9 19h6"></path>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">0
+                                                                                        results</span></div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="bases-toolbar-item bases-toolbar-sort-menu">
+                                                                                <div class="text-icon-button is-active"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-arrow-up-down">
+                                                                                            <path d="m21 16-4 4-4-4">
+                                                                                            </path>
+                                                                                            <path d="M17 20V4"></path>
+                                                                                            <path d="m3 8 4-4 4 4">
+                                                                                            </path>
+                                                                                            <path d="M7 4v16"></path>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">Sort</span><span
+                                                                                        class="flair toolbar-badge"
+                                                                                        style="display: none;">0</span>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="bases-toolbar-item bases-toolbar-filter-menu">
+                                                                                <div class="text-icon-button is-active"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-list-filter">
+                                                                                            <path d="M2 5h20"></path>
+                                                                                            <path d="M6 12h12"></path>
+                                                                                            <path d="M9 19h6"></path>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">Filter</span><span
+                                                                                        class="flair toolbar-badge"
+                                                                                        style="">2</span></div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="bases-toolbar-item bases-toolbar-properties-menu">
+                                                                                <div class="text-icon-button"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-list">
+                                                                                            <path d="M3 5h.01"></path>
+                                                                                            <path d="M3 12h.01"></path>
+                                                                                            <path d="M3 19h.01"></path>
+                                                                                            <path d="M8 5h13"></path>
+                                                                                            <path d="M8 12h13"></path>
+                                                                                            <path d="M8 19h13"></path>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">Properties</span>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="bases-toolbar-item bases-toolbar-search">
+                                                                                <div class="text-icon-button"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-search">
+                                                                                            <path d="m21 21-4.34-4.34">
+                                                                                            </path>
+                                                                                            <circle cx="11" cy="11"
+                                                                                                r="8"></circle>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">Search</span>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="bases-toolbar-item tn-bases-new-task-btn">
+                                                                                <div class="text-icon-button"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-plus">
+                                                                                            <path d="M5 12h14"></path>
+                                                                                            <path d="M12 5v14"></path>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">New</span>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="bases-toolbar-item bases-toolbar-new-item-menu">
+                                                                                <div class="text-icon-button"
+                                                                                    tabindex="0"><span
+                                                                                        class="text-button-icon"><svg
+                                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                                            width="24" height="24"
+                                                                                            viewBox="0 0 24 24"
+                                                                                            fill="none"
+                                                                                            stroke="currentColor"
+                                                                                            stroke-width="2"
+                                                                                            stroke-linecap="round"
+                                                                                            stroke-linejoin="round"
+                                                                                            class="svg-icon lucide-plus">
+                                                                                            <path d="M5 12h14"></path>
+                                                                                            <path d="M12 5v14"></path>
+                                                                                        </svg></span><span
+                                                                                        class="text-button-label">New</span>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="bases-search-row"
+                                                                        style="display: none;">
+                                                                        <div
+                                                                            class="search-input-container document-search-input">
+                                                                            <input enterkeyhint="search" type="search"
+                                                                                spellcheck="false"
+                                                                                placeholder="Find...">
+                                                                            <div class="search-input-clear-button">
+                                                                            </div>
+                                                                            <div class="document-search-count"
+                                                                                style="display: none;">Showing 0</div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="bases-error" style="display: none;">
+                                                                    </div>
+                                                                    <div class="bases-view is-grouped"
+                                                                        data-view-type="tasknotesKanban"
+                                                                        data-view-name="Subtasks">
+                                                                        <div class="tn-bases-integration tasknotes-plugin tasknotes-container tn-tasknotesKanban"
+                                                                            tabindex="-1">
+                                                                            <div class="kanban-view__board">
+                                                                                <div class="tn-bases-empty"
+                                                                                    style="padding: 20px; text-align: center; color: var(--text-muted);">
+                                                                                    No TaskNotes tasks found for this
+                                                                                    Base.</div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </span></p>
+                                                        </div>
+                                                    </div>
+                                                    <div class="embedded-backlinks" style="display: none;"></div>
+                                                </div>
+                                                <div class="cm-layer cm-layer-above cm-cursorLayer" aria-hidden="true"
+                                                    style="z-index: 150; animation-duration: 1200ms;"></div>
+                                                <div class="cm-layer cm-selectionLayer" aria-hidden="true"
+                                                    style="z-index: -2;"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="markdown-reading-view"
+                                        style="width: 100%; height: 100%; display: none;">
+                                        <div
+                                            class="markdown-preview-view markdown-rendered node-insert-event is-readable-line-width allow-fold-headings allow-fold-lists show-indentation-guide show-properties">
+                                            <div class="markdown-preview-sizer markdown-preview-section"
+                                                style="padding-bottom: 0px;"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="workspace-split mod-horizontal mod-sidedock mod-right-split" style="width: 325px;">
+                <hr class="workspace-leaf-resize-handle" style="opacity: 1;">
+                <div class="workspace-sidedock-empty-state" style="display: none;">
+                    <p class="u-muted">The sidebar is empty, try dragging a tab here.</p>
+                </div>
+                <div class="workspace-tabs mod-top mod-top-right-space" style="">
+                    <hr class="workspace-leaf-resize-handle">
+                    <div class="workspace-tab-header-container">
+                        <div class="workspace-tab-header-container-inner" style="--animation-dur: 250ms;">
+                            <div class="workspace-tab-header tappable" draggable="true"
+                                aria-label="Backlinks for Trello" data-tooltip-delay="300" data-type="backlink">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon links-coming-in">
+                                            <path
+                                                d="M8.70467 12C8.21657 11.6404 7.81269 11.1817 7.52044 10.6549C7.22819 10.1281 7.0544 9.54553 7.01086 8.94677C6.96732 8.348 7.05504 7.74701 7.26808 7.18456C7.48112 6.62212 7.81449 6.11138 8.24558 5.68697L10.7961 3.17516C11.5978 2.41258 12.6716 1.99062 13.7861 2.00016C14.9007 2.0097 15.9668 2.44997 16.755 3.22615C17.5431 4.00234 17.9902 5.05233 17.9998 6.14998C18.0095 7.24763 17.5811 8.30511 16.8067 9.09467L15.9014 10">
+                                            </path>
+                                            <path
+                                                d="M11.2953 8C11.7834 8.35957 12.1873 8.81831 12.4796 9.34512C12.7718 9.87192 12.9456 10.4545 12.9891 11.0532C13.0327 11.652 12.945 12.253 12.7319 12.8154C12.5189 13.3779 12.1855 13.8886 11.7544 14.313L9.20392 16.8248C8.40221 17.5874 7.32844 18.0094 6.21389 17.9998C5.09933 17.9903 4.03318 17.55 3.24504 16.7738C2.4569 15.9977 2.00985 14.9477 2.00016 13.85C1.99047 12.7524 2.41893 11.6949 3.19326 10.9053L4.09859 10">
+                                            </path>
+                                            <path d="M17 21L14 18L17 15"></path>
+                                            <path d="M21 18H14"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Backlinks for Trello</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true"
+                                aria-label="Outgoing links from Projects" data-tooltip-delay="300"
+                                data-type="outgoing-link">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon links-going-out">
+                                            <path
+                                                d="M8.70467 12C8.21657 11.6404 7.81269 11.1817 7.52044 10.6549C7.22819 10.1281 7.0544 9.54553 7.01086 8.94677C6.96732 8.348 7.05504 7.74701 7.26808 7.18456C7.48112 6.62212 7.81449 6.11138 8.24558 5.68697L10.7961 3.17516C11.5978 2.41258 12.6716 1.99062 13.7861 2.00016C14.9007 2.0097 15.9668 2.44997 16.755 3.22615C17.5431 4.00234 17.9902 5.05233 17.9998 6.14998C18.0095 7.24763 17.5811 8.30511 16.8067 9.09467L15.9014 10">
+                                            </path>
+                                            <path
+                                                d="M11.2953 8C11.7834 8.35957 12.1873 8.81831 12.4796 9.34512C12.7718 9.87192 12.9456 10.4545 12.9891 11.0532C13.0327 11.652 12.945 12.253 12.7319 12.8154C12.5189 13.3779 12.1855 13.8886 11.7544 14.313L9.20392 16.8248C8.40221 17.5874 7.32844 18.0094 6.21389 17.9998C5.09933 17.9903 4.03318 17.55 3.24504 16.7738C2.4569 15.9977 2.00985 14.9477 2.00016 13.85C1.99047 12.7524 2.41893 11.6949 3.19326 10.9053L4.09859 10">
+                                            </path>
+                                            <path d="M18 21L21 18L18 15"></path>
+                                            <path d="M14 18H21"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Outgoing links from Projects</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true" aria-label="Tags"
+                                data-tooltip-delay="300" data-type="tag">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-tags">
+                                            <path
+                                                d="M13.172 2a2 2 0 0 1 1.414.586l6.71 6.71a2.4 2.4 0 0 1 0 3.408l-4.592 4.592a2.4 2.4 0 0 1-3.408 0l-6.71-6.71A2 2 0 0 1 6 9.172V3a1 1 0 0 1 1-1z">
+                                            </path>
+                                            <path d="M2 7v6.172a2 2 0 0 0 .586 1.414l6.71 6.71a2.4 2.4 0 0 0 3.191.193">
+                                            </path>
+                                            <circle cx="10.5" cy="6.5" r="0.5"></circle>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Tags</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true" aria-label="All properties"
+                                data-tooltip-delay="300" data-type="all-properties">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon lucide-archive">
+                                            <rect x="2" y="3" width="20" height="5" rx="1"></rect>
+                                            <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"></path>
+                                            <path d="M10 12h4"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">All properties</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true"
+                                aria-label="Outline of Andrew Douglas" data-tooltip-delay="300" data-type="outline">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-list">
+                                            <path d="M3 5h.01"></path>
+                                            <path d="M3 12h.01"></path>
+                                            <path d="M3 19h.01"></path>
+                                            <path d="M8 5h13"></path>
+                                            <path d="M8 12h13"></path>
+                                            <path d="M8 19h13"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Outline of Andrew Douglas</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true" aria-label="Connections"
+                                data-tooltip-delay="300" data-type="smart-connections-view">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg viewBox="0 0 100 100"
+                                            class="svg-icon smart-connections">
+                                            <path d="M50,20 L80,40 L80,60 L50,100" stroke="currentColor"
+                                                stroke-width="4" fill="none"></path>
+                                            <path d="M30,50 L55,70" stroke="currentColor" stroke-width="5" fill="none">
+                                            </path>
+                                            <circle cx="50" cy="20" r="9" fill="currentColor"></circle>
+                                            <circle cx="80" cy="40" r="9" fill="currentColor"></circle>
+                                            <circle cx="80" cy="70" r="9" fill="currentColor"></circle>
+                                            <circle cx="50" cy="100" r="9" fill="currentColor"></circle>
+                                            <circle cx="30" cy="50" r="9" fill="currentColor"></circle>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Connections</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true"
+                                aria-label="File properties for Fix mtn NLP to use prefix-based parsing instead of bare word matching"
+                                data-tooltip-delay="300" data-type="file-properties">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-info">
+                                            <circle cx="12" cy="12" r="10"></circle>
+                                            <path d="M12 16v-4"></path>
+                                            <path d="M12 8h.01"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">File properties for Fix mtn NLP to use
+                                        prefix-based parsing instead of bare word matching</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true" aria-label="Footnotes"
+                                data-tooltip-delay="300" data-type="footnotes">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon lucide-file-signature">
+                                            <path
+                                                d="m18.226 5.226-2.52-2.52A2.4 2.4 0 0 0 14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-.351">
+                                            </path>
+                                            <path
+                                                d="M21.378 12.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z">
+                                            </path>
+                                            <path d="M8 18h1"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Footnotes</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable is-active" draggable="true"
+                                aria-label="Source Control" data-tooltip-delay="300" data-type="git-view">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon lucide-git-pull-request">
+                                            <circle cx="18" cy="18" r="3"></circle>
+                                            <circle cx="6" cy="6" r="3"></circle>
+                                            <path d="M13 6h3a2 2 0 0 1 2 2v7"></path>
+                                            <line x1="6" y1="9" x2="6" y2="21"></line>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">Source Control</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                            <div class="workspace-tab-header tappable" draggable="true" aria-label="History"
+                                data-tooltip-delay="300" data-type="git-history-view">
+                                <div class="workspace-tab-header-inner">
+                                    <div class="workspace-tab-header-inner-icon iconic-icon"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round"
+                                            class="svg-icon lucide-history">
+                                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
+                                            <path d="M3 3v5h5"></path>
+                                            <path d="M12 7v5l4 2"></path>
+                                        </svg></div>
+                                    <div class="workspace-tab-header-inner-title">History</div>
+                                    <div class="workspace-tab-header-status-container"></div>
+                                    <div class="workspace-tab-header-inner-close-button" aria-label="Close"><svg
+                                            xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                            stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-x">
+                                            <path d="M18 6 6 18"></path>
+                                            <path d="m6 6 12 12"></path>
+                                        </svg></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="workspace-tab-header-new-tab"><span class="clickable-icon" aria-label="New tab"><svg
+                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" class="svg-icon lucide-plus">
+                                    <path d="M5 12h14"></path>
+                                    <path d="M12 5v14"></path>
+                                </svg></span></div>
+                        <div class="workspace-tab-header-spacer"></div>
+                        <div class="workspace-tab-header-tab-list"><span class="clickable-icon"><svg
+                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" class="svg-icon lucide-chevron-down">
+                                    <path d="m6 9 6 6 6-6"></path>
+                                </svg></span></div>
+                        <div class="sidebar-toggle-button mod-right" aria-label="" data-tooltip-position="left">
+                            <div class="clickable-icon iconic-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                    height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                    stroke-linecap="round" stroke-linejoin="round"
+                                    class="svg-icon sidebar-toggle-button-icon">
+                                    <rect x="1" y="2" width="22" height="20" rx="4"></rect>
+                                    <rect x="4" y="5" width="2" height="14" rx="2" fill="currentColor"
+                                        class="sidebar-toggle-icon-inner"></rect>
+                                </svg></div>
+                        </div>
+                    </div>
+                    <div class="workspace-tab-container">
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                        <div class="workspace-leaf">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content" data-type="git-view">
+                                <div class="view-header">
+                                    <div class="view-header-left">
+                                        <div class="view-header-nav-buttons"><button class="clickable-icon"
+                                                aria-disabled="true" aria-label="Navigate back"><svg
+                                                    xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                    viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                    stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                    class="svg-icon lucide-arrow-left">
+                                                    <path d="m12 19-7-7 7-7"></path>
+                                                    <path d="M19 12H5"></path>
+                                                </svg></button><button class="clickable-icon" aria-disabled="true"
+                                                aria-label="Navigate forward"><svg xmlns="http://www.w3.org/2000/svg"
+                                                    width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                                    stroke-linejoin="round" class="svg-icon lucide-arrow-right">
+                                                    <path d="M5 12h14"></path>
+                                                    <path d="m12 5 7 7-7 7"></path>
+                                                </svg></button></div>
+                                    </div>
+                                    <div class="view-header-title-container mod-at-start mod-fade mod-at-end">
+                                        <div class="view-header-title-parent"></div>
+                                        <div class="view-header-title">Source Control</div>
+                                    </div>
+                                    <div class="view-actions"><button class="clickable-icon view-action mod-bookmark"
+                                            aria-label="Bookmark"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-bookmark">
+                                                <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"></path>
+                                            </svg></button><button class="clickable-icon view-action"
+                                            aria-label="More options"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                class="svg-icon lucide-more-vertical">
+                                                <circle cx="12" cy="12" r="1"></circle>
+                                                <circle cx="12" cy="5" r="1"></circle>
+                                                <circle cx="12" cy="19" r="1"></circle>
+                                            </svg></button></div>
+                                </div>
+                                <div class="view-content">
+                                    <main class="git-view svelte-5wq9p" data-type="git-view">
+                                        <div class="nav-header">
+                                            <div class="nav-buttons-container">
+                                                <div id="backup-btn" data-icon="arrow-up-circle"
+                                                    class="clickable-icon nav-action-button"
+                                                    aria-label="Commit-and-sync"><svg xmlns="http://www.w3.org/2000/svg"
+                                                        width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                                        stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                                        stroke-linejoin="round" class="svg-icon lucide-arrow-up-circle">
+                                                        <circle cx="12" cy="12" r="10"></circle>
+                                                        <path d="m16 12-4-4-4 4"></path>
+                                                        <path d="M12 16V8"></path>
+                                                    </svg></div>
+                                                <div id="commit-btn" data-icon="check"
+                                                    class="clickable-icon nav-action-button" aria-label="Commit"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon lucide-check">
+                                                        <path d="M20 6 9 17l-5-5"></path>
+                                                    </svg></div>
+                                                <div id="stage-all" class="clickable-icon nav-action-button"
+                                                    data-icon="plus-circle" aria-label="Stage all"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon lucide-plus-circle">
+                                                        <circle cx="12" cy="12" r="10"></circle>
+                                                        <path d="M8 12h8"></path>
+                                                        <path d="M12 8v8"></path>
+                                                    </svg></div>
+                                                <div id="unstage-all" class="clickable-icon nav-action-button"
+                                                    data-icon="minus-circle" aria-label="Unstage all"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon lucide-minus-circle">
+                                                        <circle cx="12" cy="12" r="10"></circle>
+                                                        <path d="M8 12h8"></path>
+                                                    </svg></div>
+                                                <div id="push" class="clickable-icon nav-action-button"
+                                                    data-icon="upload" aria-label="Push"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon lucide-upload">
+                                                        <path d="M12 3v12"></path>
+                                                        <path d="m17 8-5-5-5 5"></path>
+                                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                                    </svg></div>
+                                                <div id="pull" class="clickable-icon nav-action-button"
+                                                    data-icon="download" aria-label="Pull"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon lucide-download">
+                                                        <path d="M12 15V3"></path>
+                                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                                        <path d="m7 10 5 5 5-5"></path>
+                                                    </svg></div>
+                                                <div id="layoutChange" class="clickable-icon nav-action-button"
+                                                    aria-label="Change Layout" data-icon="list"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon lucide-list">
+                                                        <path d="M3 5h.01"></path>
+                                                        <path d="M3 12h.01"></path>
+                                                        <path d="M3 19h.01"></path>
+                                                        <path d="M8 5h13"></path>
+                                                        <path d="M8 12h13"></path>
+                                                        <path d="M8 19h13"></path>
+                                                    </svg></div>
+                                                <div id="refresh" data-icon="refresh-cw" aria-label="Refresh"
+                                                    class="clickable-icon nav-action-button"><svg
+                                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                                        class="svg-icon lucide-refresh-cw">
+                                                        <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8">
+                                                        </path>
+                                                        <path d="M21 3v5h-5"></path>
+                                                        <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16">
+                                                        </path>
+                                                        <path d="M8 16H3v5"></path>
+                                                    </svg></div>
+                                            </div>
+                                        </div>
+                                        <div class="git-commit-msg svelte-5wq9p"><textarea
+                                                class="commit-msg-input svelte-5wq9p" spellcheck="true"
+                                                placeholder="Commit Message" rows="1"></textarea>
+                                            <div class="git-commit-msg-clear-button svelte-5wq9p" aria-label="Clear">
+                                            </div><!---->
+                                        </div>
+                                        <div class="nav-files-container" style="position: relative;">
+                                            <div class="tree-item nav-folder mod-root">
+                                                <div class="staged tree-item nav-folder">
+                                                    <div
+                                                        class="tree-item-self is-clickable nav-folder-title svelte-5wq9p">
+                                                        <div
+                                                            class="tree-item-icon nav-folder-collapse-indicator collapse-icon">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                height="24" viewBox="0 0 24 24" fill="none"
+                                                                stroke="currentColor" stroke-width="2"
+                                                                stroke-linecap="round" stroke-linejoin="round"
+                                                                class="svg-icon right-triangle">
+                                                                <path d="M3 8L12 17L21 8"></path>
+                                                            </svg></div>
+                                                        <div class="tree-item-inner nav-folder-title-content">Staged
+                                                            Changes</div>
+                                                        <div class="git-tools svelte-5wq9p">
+                                                            <div class="buttons">
+                                                                <div data-icon="minus" aria-label="Unstage"
+                                                                    class="clickable-icon"><svg
+                                                                        xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                        height="24" viewBox="0 0 24 24" fill="none"
+                                                                        stroke="currentColor" stroke-width="2"
+                                                                        stroke-linecap="round" stroke-linejoin="round"
+                                                                        class="svg-icon lucide-minus">
+                                                                        <path d="M5 12h14"></path>
+                                                                    </svg></div>
+                                                            </div>
+                                                            <div class="files-count svelte-5wq9p">0</div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="tree-item-children nav-folder-children">
+                                                        <main class="topLevel"><!---->
+                                                            <main><!----></main><!---->
+                                                        </main><!---->
+                                                    </div><!---->
+                                                </div>
+                                                <div class="changes tree-item nav-folder">
+                                                    <div
+                                                        class="tree-item-self is-clickable nav-folder-title svelte-5wq9p">
+                                                        <div
+                                                            class="tree-item-icon nav-folder-collapse-indicator collapse-icon">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                height="24" viewBox="0 0 24 24" fill="none"
+                                                                stroke="currentColor" stroke-width="2"
+                                                                stroke-linecap="round" stroke-linejoin="round"
+                                                                class="svg-icon right-triangle">
+                                                                <path d="M3 8L12 17L21 8"></path>
+                                                            </svg></div>
+                                                        <div class="tree-item-inner nav-folder-title-content">Changes
+                                                        </div>
+                                                        <div class="git-tools svelte-5wq9p">
+                                                            <div class="buttons">
+                                                                <div data-icon="undo" aria-label="Discard"
+                                                                    class="clickable-icon"><svg
+                                                                        xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                        height="24" viewBox="0 0 24 24" fill="none"
+                                                                        stroke="currentColor" stroke-width="2"
+                                                                        stroke-linecap="round" stroke-linejoin="round"
+                                                                        class="svg-icon lucide-undo">
+                                                                        <path d="M3 7v6h6"></path>
+                                                                        <path
+                                                                            d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13">
+                                                                        </path>
+                                                                    </svg></div>
+                                                                <div data-icon="plus" aria-label="Stage"
+                                                                    class="clickable-icon"><svg
+                                                                        xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                        height="24" viewBox="0 0 24 24" fill="none"
+                                                                        stroke="currentColor" stroke-width="2"
+                                                                        stroke-linecap="round" stroke-linejoin="round"
+                                                                        class="svg-icon lucide-plus">
+                                                                        <path d="M5 12h14"></path>
+                                                                        <path d="M12 5v14"></path>
+                                                                    </svg></div>
+                                                            </div>
+                                                            <div class="files-count svelte-5wq9p">0</div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="tree-item-children nav-folder-children">
+                                                        <main class="topLevel"><!---->
+                                                            <main><!----></main><!---->
+                                                        </main><!---->
+                                                    </div><!---->
+                                                </div> <!---->
+                                            </div><!---->
+                                        </div>
+                                    </main>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="workspace-leaf" style="display: none;">
+                            <hr class="workspace-leaf-resize-handle">
+                            <div class="workspace-leaf-content node-insert-event" data-type="undefined"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="workspace-ribbon side-dock-ribbon mod-right"></div>
+        </div>
+    </div>
+    <div class="status-bar">
+        <div class="status-bar-item plugin-backlink mod-clickable">1 backlink</div>
+        <div class="status-bar-item plugin-properties mod-clickable">9 properties</div>
+        <div class="status-bar-item plugin-editor-status mod-clickable" style="" aria-label="Live Preview"
+            data-tooltip-position="top"><span class="status-bar-item-icon"><svg xmlns="http://www.w3.org/2000/svg"
+                    width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-edit-3">
+                    <path d="M13 21h8"></path>
+                    <path
+                        d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z">
+                    </path>
+                </svg></span></div>
+        <div class="status-bar-item plugin-word-count" style=""><span class="status-bar-item-segment">492
+                words</span><span class="status-bar-item-segment">4,007 characters</span></div>
+        <div class="status-bar-item plugin-sync" aria-label="Fully synced" data-tooltip-position="top">
+            <div class="status-bar-item-segment"><span class="status-bar-item-icon sync-status-icon mod-success"><svg
+                        xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        class="svg-icon check-small">
+                        <path
+                            d="M12 21C16.9707 21 21 16.9707 21 12C21 7.0293 16.9707 3 12 3C7.0293 3 3 7.0293 3 12C3 16.9707 7.0293 21 12 21Z">
+                        </path>
+                        <path d="M7.5 12.5L10.5 15.5L16 10"></path>
+                    </svg></span></div>
+        </div>
+        <div class="status-bar-item plugin-obsidian-git obsidian-git-statusbar-idle obsidian-git-statusbar-status obsidian-git-statusbar-pull obsidian-git-statusbar-message obsidian-git-statusbar-add obsidian-git-statusbar-commit obsidian-git-statusbar-push"
+            data-tooltip-position="top" aria-label="Last Commit: a minute ago">
+            <div data-tooltip-position="top" style="float: left;"></div>
+            <div data-tooltip-position="top" style="float: left;"></div>
+            <div style="float: left;"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                    class="svg-icon lucide-check">
+                    <path d="M20 6 9 17l-5-5"></path>
+                </svg></div>
+            <div style="float: right; margin-left: 5px;">0</div>
+        </div>
+        <div class="status-bar-item plugin-obsidian-git mod-clickable">main</div>
+        <div class="status-bar-item plugin-smart-connections"><a class="smart-env-status-container" role="button"
+                title="Smart Environment status" aria-label="Smart Environment status" tabindex="0">
+                <span class="smart-env-status-icon" aria-hidden="true"><svg viewBox="0 0 100 100"
+                        class="svg-icon smart-connections">
+                        <path d="M50,20 L80,40 L80,60 L50,100" stroke="currentColor" stroke-width="4" fill="none">
+                        </path>
+                        <path d="M30,50 L55,70" stroke="currentColor" stroke-width="5" fill="none"></path>
+                        <circle cx="50" cy="20" r="9" fill="currentColor"></circle>
+                        <circle cx="80" cy="40" r="9" fill="currentColor"></circle>
+                        <circle cx="80" cy="70" r="9" fill="currentColor"></circle>
+                        <circle cx="50" cy="100" r="9" fill="currentColor"></circle>
+                        <circle cx="30" cy="50" r="9" fill="currentColor"></circle>
+                    </svg></span>
+                <span class="smart-env-status-msg" aria-live="polite">Smart Env 2.2.8</span>
+                <span class="smart-env-status-indicator" title="Open notifications" aria-label="Open notifications feed"
+                    role="button" tabindex="0" data-count="176" data-level="info"></span>
+            </a></div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

- Make `rightRibbon` handling null-safe (optional property, guarded event registration)
- Add right-edge hover fallback trigger for right sidebar expansion
- Preserve existing ribbon hover behavior when right ribbon is present
- Block edge-trigger expansion while modals or menus are open
- Increase default sidebar widths from 252 to 325

## Problem

Some Obsidian layouts do not expose a usable right ribbon hover target (`workspace.rightRibbon.containerEl`), so right sidebar hover never triggers. Additionally, without a modal guard, edge-trigger detection could fire while the settings dialog or context menus are open.

## Changes

### Right-edge fallback (`mousemove` on `document`)
When the right sidebar feature is enabled and not pinned, a `mousemove` listener detects the cursor within `RIGHT_EDGE_TRIGGER_PX` (20px) of the right window edge and expands the sidebar. If the cursor moves away from the edge and is not inside the sidebar, it collapses.

### Null-safe right ribbon
- `rightRibbon` changed from `HTMLElement` to `HTMLElement | undefined`
- Initialization uses optional chaining: `(this.app.workspace.rightRibbon as any)?.containerEl`
- `mouseenter` and `dblclick` registrations are guarded with `if (this.rightRibbon)`

### Modal/menu guard
`isModalOrMenuOpen()` checks for `.modal-container` and `.menu` in the DOM and suppresses edge-trigger expansion while either is present.

### Default sidebar widths
Increased from 252 to 325 for a more usable default.

### DevDependencies
Updated rollup v2 to v4, typescript to v5, all plugins to current. Resolves all npm audit vulnerabilities (0 remaining).

## Testing

Built successfully with `npm run build` (rollup v4, typescript v5). Zero audit vulnerabilities.

Fixes toiq/obsidian-sidebar-expand-on-hover#19
